### PR TITLE
[WIP] support dropping item by pc user

### DIFF
--- a/src/shoghicp/BigBrother/network/Translator.php
+++ b/src/shoghicp/BigBrother/network/Translator.php
@@ -36,6 +36,7 @@ use pocketmine\network\mcpe\protocol\PlayerActionPacket;
 use pocketmine\network\mcpe\protocol\MobArmorEquipmentPacket;
 use pocketmine\network\mcpe\protocol\MobEquipmentPacket;
 use pocketmine\network\mcpe\protocol\MobEffectPacket;
+use pocketmine\network\mcpe\protocol\DropItemPacket;
 use pocketmine\network\mcpe\protocol\RemoveBlockPacket;
 use pocketmine\network\mcpe\protocol\UseItemPacket;
 use pocketmine\utils\BinaryStream;
@@ -354,6 +355,13 @@ class Translator{
 						}else{
 							echo "PlayerDiggingPacket: ".$packet->status."\n";
 						}
+					break;
+					case 3:
+					case 4:
+						$pk = new DropItemPacket();
+						$pk->item = $player->getInventory()->getItemInHand();
+						if($packet->status === 4) $pk->item->count = 1;
+						return $pk;
 					break;
 					case 5:
 						$item = $player->getInventory()->getItemInHand();


### PR DESCRIPTION
## Introduction
**!! DO NOT MERGE UNTIL INVENTORY FEATURE IS FULLY IMPLEMENTED !!**
This pull-request is intended to just advertise my work.

This patch allow PC users to drop any number of item they have.
Currently this patch only support dropping item from hand slot only.

Since PocketEdition not support dropping item one by one, or any number of item (not whole stack of item)、PocketMine-MP interprets `DropItemPacket` as action which dorp whole stack of item. So I wrote a patch to solve this problem, and send pull-request to pmmp repository (See, below).

https://github.com/pmmp/PocketMine-MP/pull/1147

### Behavioural changes
* suppor dropping item when pc user press <kbd>q</kbd> or <kbd>CTRL</kbd>+<kbd>q</kbd>

### Follow-up
* we need to consider dropping item from inventory directory (i mean not from a hotbar)
  In vanilla server, pc user can drop item from inventory by clicking outside of inventory window.

Any suggestions is welcome!!