### PR TITLE
limit the location that chest can be placed

### DIFF
--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -20,6 +20,7 @@ namespace shoghicp\BigBrother;
 use pocketmine\plugin\PluginBase;
 use pocketmine\network\mcpe\protocol\ProtocolInfo as Info;
 use pocketmine\block\Block;
+use pocketmine\block\Chest;
 use pocketmine\event\player\PlayerRespawnEvent;
 use pocketmine\event\block\BlockPlaceEvent;
 use pocketmine\event\Listener;
@@ -168,6 +169,26 @@ class BigBrother extends PluginBase implements Listener{
 				$pk->y = $block->y;
 				$pk->z = $block->z;
 				$player->putRawPacket($pk);
+			}
+		}
+
+		if($block instanceof Chest){
+			$num_side_chest = 0;
+			for($i=2; $i<=5; ++$i){
+				if(($side_chest = $block->getSide($i))->getId() === $block->getId()){
+					++$num_side_chest;
+					for($j=2; $j<=5; ++$j){
+						// cancel block placement event if side chest is already large-chest
+						if($side_chest->getSide($j)->getId() === $side_chest->getId()){
+							$event->setCancelled();
+						}
+					}
+				}
+			}
+
+			// cancel if there are more than one chest that can be large-chest
+			if($num_side_chest > 1){
+				$event->setCancelled();
 			}
 		}
 	}


### PR DESCRIPTION
## Introduction
This change-set limit the location that chest can be placed.
Since Minecraft PE has no limitation for the location to chest can be placed,
PocketMine-MP allow player to place the chest anywhere.
But this behaviour is not compatible with PC Edition.

In PC edition, the chest illegally located is invisible.  
So, I wrote the patch to make it compatible with PC edition.

### Behavioural changes
* cancel block placement event if side chest is already large-chest
* cancel block placement event if there are more than one side chest can be large-chest

This patch also limit the block placement event by PocketEdition player to compatible with PC edition.

### Follow-up
I tested this code with pmmp (master branch b4a149cce81bfce22bb57e07554946620ecb2f74), and Minecraft PC Edition v1.12 Vanilla.
But it may contains a bug I didn't noticed. Or if you find something that make this patch better, please tell me in the comment.