### PR TITLE
fix slot index of `EntityEquipmentPacket`

### DIFF
--- a/src/shoghicp/BigBrother/network/Translator.php
+++ b/src/shoghicp/BigBrother/network/Translator.php
@@ -369,7 +369,7 @@ class Translator{
 							$dropItem = $player->getInventory()->getItemInHand();
 						}
 
-						$player->getInventory()->setItem($player->getInventory()->getHeldItemSlot(), $item);
+						$player->getInventory()->setItemInHand($item);
 						$player->getLevel()->dropItem($player->add(0, 1.3, 0), $dropItem, $player->getDirectionVector()->multiply(0.4), 40);
 
 						return null;
@@ -1313,7 +1313,7 @@ class Translator{
 				foreach($packet->slots as $num => $item){
 					$pk = new EntityEquipmentPacket();
 					$pk->eid = $packet->entityRuntimeId;
-					$pk->slot = $num + 2;
+					$pk->slot = 2 + 3 - $num;
 					$pk->item = $item;
 					$packets[] = $pk;
 				}


### PR DESCRIPTION
## Introduction
I'm not sure why MOJANG implement the slot index of `MobArmorEquipmentPacket` in different order.
But, it seems the slot index starts with offset 2 in reverse order. So, I wrote this patch to fix it.

**FYI:**
First slot index of `EntityEquipmentPacket` is main-hand, and second one is off-hand.

### Behavioural changes
* fix the slot index of `EntityEquipmentPacket` which translated from `MobArmorEquipmentPacket`

### Follow-up
not to mention, currently inventory of pc client is not fully implemented yet.
so, I just confirm only that the PE user can change armor equipment and visible from PC client.