### PR TITLE
Support item frame for MCPC

### DIFF
--- a/src/shoghicp/BigBrother/DesktopChunk.php
+++ b/src/shoghicp/BigBrother/DesktopChunk.php
@@ -29,9 +29,11 @@ declare(strict_types=1);
 
 namespace shoghicp\BigBrother;
 
+use pocketmine\block\Block;
 use pocketmine\level\format\io\LevelProvider;
 use shoghicp\BigBrother\utils\Binary;
 use shoghicp\BigBrother\utils\ConvertUtils;
+use shoghicp\BigBrother\entity\ItemFrameBlockEntity;
 
 class DesktopChunk{
 	/** @var DesktopPlayer */
@@ -93,8 +95,13 @@ class DesktopChunk{
 						$blockid = $subChunk->getBlockId($x, $y, $z);
 						$blockdata = $subChunk->getBlockData($x, $y, $z);
 
-						ConvertUtils::convertBlockData(true, $blockid, $blockdata);
-						$block = (int) ($blockid << 4) | $blockdata;
+						if($blockid == Block::FRAME_BLOCK){
+							ItemFrameBlockEntity::getItemFrame($this->player->getLevel(), $x + ($this->chunkX << 4), $y + ($num << 4), $z + ($this->chunkZ << 4), $blockdata, true);
+							$block = Block::AIR;
+						}else{
+							ConvertUtils::convertBlockData(true, $blockid, $blockdata);
+							$block = (int) ($blockid << 4) | $blockdata;
+						}
 
 						if(($key = array_search($block, $palette, true)) !== false){
 							$data .= chr($key);//bit

--- a/src/shoghicp/BigBrother/entity/ItemFrameBlockEntity.php
+++ b/src/shoghicp/BigBrother/entity/ItemFrameBlockEntity.php
@@ -1,0 +1,245 @@
+<?php
+/**
+ *  ______  __         ______               __    __
+ * |   __ \|__|.-----.|   __ \.----..-----.|  |_ |  |--..-----..----.
+ * |   __ <|  ||  _  ||   __ <|   _||  _  ||   _||     ||  -__||   _|
+ * |______/|__||___  ||______/|__|  |_____||____||__|__||_____||__|
+ *             |_____|
+ *
+ * BigBrother plugin for PocketMine-MP
+ * Copyright (C) 2014-2015 shoghicp <https://github.com/shoghicp/BigBrother>
+ * Copyright (C) 2016- BigBrotherTeam
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @author BigBrotherTeam
+ * @link   https://github.com/BigBrotherTeam/BigBrother
+ *
+ */
+
+declare(strict_types=1);
+
+namespace shoghicp\BigBrother\entity;
+
+use pocketmine\item\Item;
+use pocketmine\block\Block;
+use pocketmine\level\Level;
+use pocketmine\level\Position;
+use pocketmine\entity\Entity;
+use pocketmine\tile\ItemFrame;
+use pocketmine\utils\UUID;
+use shoghicp\BigBrother\network\protocol\Play\Server\DestroyEntitiesPacket;
+use shoghicp\BigBrother\network\protocol\Play\Server\SpawnObjectPacket;
+use shoghicp\BigBrother\network\protocol\Play\Server\EntityMetadataPacket;
+use shoghicp\BigBrother\utils\ConvertUtils;
+use shoghicp\BigBrother\DesktopPlayer;
+
+class ItemFrameBlockEntity extends Position{
+	/** @var array */
+	protected static $itemFrames = [];
+	/** @var array */
+	protected static $itemFramesAt = [];
+	/** @var array */
+	protected static $itemFramesInChunk = [];
+
+	/** @var array */
+	private static $mapping = [
+		0 => [ -90,  3],//EAST
+		1 => [ +90,  1],//WEST
+		2 => [   0,  0],//SOUTH
+		3 => [-180,  2] //NORTH
+	];
+
+	/** @var int */
+	private $eid;
+	/** @var string */
+	private $uuid;
+	/** @var int */
+	private $facing;
+	/** @var int */
+	private $yaw;
+
+	/**
+	 * @param Level $level
+	 * @param int   $x
+	 * @param int   $y
+	 * @param int   $z
+	 * @param int   $data
+	 */
+	private function __construct(Level $level, int $x, int $y, int $z, int $data){
+		parent::__construct($x, $y, $z, $level);
+
+		$prop = (new \ReflectionClass(Entity::class))->getProperty("entityCount");
+		$prop->setAccessible(true);
+		$this->eid = $prop->getValue();
+		$prop->setValue($this->eid + 1);
+
+		$this->uuid = UUID::fromRandom()->toBinary();
+		$this->facing = $data;
+		$this->yaw = self::$mapping[$data][0] ?? 0;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getEntityId() : int{
+		return $this->eid;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getFacing() : int{
+		return $this->facing;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function hasItem() : bool{
+		$retval = false;
+		$tile = $this->getLevel()->getTile($this);
+		if($tile instanceof ItemFrame){
+			$retval = $tile->hasItem();
+		}
+		return $retval;
+	}
+
+	/**
+	 * @param DesktopPlayer $player
+	 */
+	public function spawnTo(DesktopPlayer $player){
+		$pk = new SpawnObjectPacket();
+		$pk->eid = $this->eid;
+		$pk->uuid = $this->uuid;
+		$pk->type = SpawnObjectPacket::ITEM_FRAMES;
+		$pk->x = $this->x;
+		$pk->y = $this->y;
+		$pk->z = $this->z;
+		$pk->yaw = $this->yaw;
+		$pk->pitch = 0;
+		$pk->data = self::$mapping[$this->facing][1];
+		$pk->sendVelocity = true;
+		$pk->velocityX = 0;
+		$pk->velocityY = 0;
+		$pk->velocityZ = 0;
+		$player->putRawPacket($pk);
+
+		$pk = new EntityMetadataPacket();
+		$pk->eid = $this->eid;
+		$pk->metadata = ["convert" => true];
+
+		$tile = $this->getLevel()->getTile($this);
+		if($tile instanceof ItemFrame){
+			$item = $tile->hasItem() ? $tile->getItem() : Item::get(Item::AIR, 0, 0);
+			ConvertUtils::convertItemData(true, $item);
+			$pk->metadata[6] = [5, $item];
+			$pk->metadata[7] = [1, $tile->getItemRotation()];
+		}
+
+		$player->putRawPacket($pk);
+	}
+
+	/**
+	 * @param DesktopPlayer $player
+	 */
+	public function despawnFrom(DesktopPlayer $player) : void{
+		$pk = new DestroyEntitiesPacket();
+		$pk->ids []= $this->eid;
+		$player->putRawPacket($pk);
+	}
+
+	public function despawnFromAll() : void{
+		foreach($this->getLevel()->getChunkPlayers($this->x >> 4, $thix->z >> 4) as $player){
+			if($player instanceof DesktopPlayer){
+				$this->despawnFrom($player);
+			}
+		}
+		self::removeItemFrame($this);
+	}
+
+	/**
+	 * @param Level $level
+	 * @param int   $x
+	 * @param int   $y
+	 * @param int   $z
+	 * @return bool
+	 */
+	public static function exists(Level $level, int $x, int $y, int $z) : bool{
+		return isset(self::$itemFramesAt[$level->getId()][Level::blockHash($x, $y, $z)]);
+	}
+
+	/**
+	 * @param Level $level
+	 * @param int   $x
+	 * @param int   $y
+	 * @param int   $z
+	 * @param int   $data
+	 * @param bool  $create
+	 * @return ItemFrameBlockEntity|null
+	 */
+	public static function getItemFrame(Level $level, int $x, int $y, int $z, int $data=0, bool $create=false) : ?ItemFrameBlockEntity{
+		$entity = null;
+
+		if(isset(self::$itemFramesAt[$level_id = $level->getId()][$index = Level::blockHash($x, $y, $z)])){
+			$entity = self::$itemFramesAt[$level_id][$index];
+		}elseif($create){
+			$entity = new ItemFrameBlockEntity($level, $x, $y, $z, $data);
+			self::$itemFrames[$level_id][$entity->eid] = $entity;
+			self::$itemFramesAt[$level_id][$index] = $entity;
+
+			if(!isset(self::$itemFramesInChunk[$level_id][$index = Level::chunkHash($x >> 4, $z >> 4)])){
+				self::$itemFramesInChunk[$level_id][$index] = [];
+			}
+			self::$itemFramesInChunk[$level_id][$index] []= $entity;
+		}
+
+		return $entity;
+	}
+
+	/**
+	 * @param Level $level
+	 * @param int   $eid
+	 * @return ItemFrameBlockEntity|null
+	 */
+	public static function getItemFrameById(Level $level, int $eid) : ?ItemFrameBlockEntity{
+		return self::$itemFrames[$level->getId()][$eid] ?? null;
+	}
+
+	/**
+	 * @param Block $block
+	 * @param bool  $create
+	 * @return ItemFrameBlockEntity|null
+	 */
+	public static function getItemFrameByBlock(Block $block, bool $create=false) : ?ItemFrameBlockEntity{
+		return self::getItemFrame($block->getLevel(), $block->x, $block->y, $block->z, $block->getDamage(), $create);
+	}
+
+	/**
+	 * @param Level $level
+	 * @param int   $x
+	 * @param int   $z
+	 */
+	public static function getItemFramesInChunk(Level $level, int $x, int $z) : array{
+		return self::$itemFramesInChunk[$level->getId()][Level::chunkHash($x, $z)] ?? [];
+	}
+
+	/**
+	 * @param ItemFrameBlockEntity $entity
+	 */
+	public static function removeItemFrame(ItemFrameBlockEntity $entity) : void{
+		unset(self::$itemFrames[$entity->level->getid()][$entity->eid]);
+		unset(self::$itemFramesAt[$entity->level->getId()][Level::blockHash($entity->x, $entity->y, $entity->z)]);
+		if(isset(self::$itemFramesInChunk[$level_id = $entity->getLevel()->getId()][$index = Level::chunkHash($entity->x >> 4, $entity->z >> 4)])){
+			self::$itemFramesInChunk[$level_id][$index] = array_diff(self::$itemFramesInChunk[$level_id][$index], [$entity]);
+		}
+	}
+}

--- a/src/shoghicp/BigBrother/network/Translator.php
+++ b/src/shoghicp/BigBrother/network/Translator.php
@@ -109,6 +109,7 @@ use shoghicp\BigBrother\network\protocol\Play\Server\UpdateHealthPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\UpdateBlockEntityPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\UseBedPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\NamedSoundEffectPacket;
+use shoghicp\BigBrother\network\protocol\Play\Client\UseEntityPacket;
 use shoghicp\BigBrother\utils\ConvertUtils;
 
 class Translator{
@@ -204,7 +205,7 @@ class Translator{
 				return null;
 
 			case InboundPacket::USE_ENTITY_PACKET:
-				if($packet->type === 2){//interact at
+				if($packet->type === UseEntityPacket::INTERACT_AT){
 					$pk = new InteractPacket();
 					$pk->target = $packet->target;
 					$pk->action = InteractPacket::ACTION_MOUSEOVER;
@@ -222,10 +223,10 @@ class Translator{
 					$pk->trData->vector2 = new Vector3(0, 0, 0);
 
 					switch($packet->type){
-						case 0://interact
+						case UseEntityPacket::INTERACT:
 							$pk->trData->actionType = InventoryTransactionPacket::USE_ITEM_ON_ENTITY_ACTION_INTERACT;
 						break;
-						case 1://attack
+						case UseEntityPacket::ATTACK:
 							$pk->trData->actionType = InventoryTransactionPacket::USE_ITEM_ON_ENTITY_ACTION_ATTACK;
 						break;
 						default:

--- a/src/shoghicp/BigBrother/network/Translator.php
+++ b/src/shoghicp/BigBrother/network/Translator.php
@@ -1151,7 +1151,7 @@ class Translator{
 				$pk = new SpawnObjectPacket();
 				$pk->eid = $packet->entityRuntimeId;
 				$pk->uuid = UUID::fromRandom()->toBinary();
-				$pk->type = 2;
+				$pk->type = SpawnObjectPacket::ITEM_STACK;
 				$pk->x = $packet->position->x;
 				$pk->y = $packet->position->y;
 				$pk->z = $packet->position->z;

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/UseEntityPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/UseEntityPacket.php
@@ -33,6 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class UseEntityPacket extends InboundPacket{
 
+	const INTERACT    = 0;
+	const ATTACK      = 1;
+	const INTERACT_AT = 2;
+
 	/** @var int */
 	public $target;
 	/** @var int */
@@ -55,12 +59,12 @@ class UseEntityPacket extends InboundPacket{
 	protected function decode() : void{
 		$this->target = $this->getVarInt();
 		$this->type = $this->getVarInt();
-		if($this->type === 2){
+		if($this->type === self::INTERACT_AT){
 			$this->targetX = $this->getFloat();
 			$this->targetY = $this->getFloat();
 			$this->targetZ = $this->getFloat();
 		}
-		if($this->type !== 1){
+		if($this->type !== self::ATTACK){
 			$this->hand = $this->getVarInt();
 		}
 	}

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnObjectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnObjectPacket.php
@@ -33,6 +33,34 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SpawnObjectPacket extends OutboundPacket{
 
+	const BOAT              =  1;
+	const ITEM_STACK        =  2;
+	const AREA_EFFECT_CLOUD =  3;
+	const MINECART          = 10;
+	const ACTIVATED_TNT     = 50;
+	const ENDERCRYSTAL      = 51;
+	const TIPPED_ARROW      = 60;
+	const SNOWBALL          = 61;
+	const EGG               = 62;
+	const FIREBALL          = 63;
+	const FIRECHARGE        = 64;
+	const THROWN_ENDERPEARL = 65;
+	const WITHER_SKULL      = 66;
+	const SHULKER_BULLET    = 67;
+	const LLAMA_SPIT        = 68;
+	const FALLING_OBJECTS   = 70;
+	const ITEM_FRAMES       = 71;
+	const EYE_OF_ENDER      = 72;
+	const THROWN_POTION     = 73;
+	const THROWN_EXP_BOTTLE = 75;
+	const FIREWORK_ROCKET   = 76;
+	const LEASH_KNOT        = 77;
+	const ARMORSTAND        = 78;
+	const EVOCATION_FANGS   = 79;
+	const FISHING_HOOK      = 90;
+	const SPECTRAL_ARROW    = 91;
+	const DRAGON_FIREBALL   = 93;
+
 	/** @var int */
 	public $eid;
 	/** @var string */


### PR DESCRIPTION
## Introduction
This patch support behavior of MCPC's ItemFrame entity which is corresponding to MCPE's ItemFrame block.

### Behavioural changes
* When PE user put ItemFrame block, send SpawnObjectPacket (Entity) to PC users
* When PC user interact with ItemFrame entities by UseItemPacket, translate it to InventoryTransactionPacket for PE user
* Fix DesktopPlayer#unloadChunk() method works correctly
### Follow-up
I carefully tested this patch, but it may contains some bug or something strange.
Please tell me if u found something wrong.

<!--- Thank you for sending pull-request! -->