### PR TITLE
Add additional debug info to show prerequisite conditions

### DIFF
--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -91,6 +91,16 @@ class BigBrother extends PluginBase implements Listener{
 
 				$this->getLogger()->info("PHP version: ".PHP_VERSION);
 
+				if(!$this->isPhar() and is_dir($this->getDataFolder().".git")){
+					$cwd = getcwd();
+					chdir($this->getDataFolder());
+					@exec("git describe --tags --always --dirty", $revision, $retval);
+					if($retval == 0){
+						$this->getLogger()->info("BigBrother revision: ".$revision[0]);
+					}
+					chdir($cwd);
+				}
+
 				$aes = new AES();
 				switch($aes->getEngine()){
 					case AES::ENGINE_OPENSSL:

--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -89,6 +89,8 @@ class BigBrother extends PluginBase implements Listener{
 				$this->saveResource("openssl.cnf", false);
 				$this->reloadConfig();
 
+				$this->getLogger()->info("PHP version: ".PHP_VERSION);
+
 				$aes = new AES();
 				switch($aes->getEngine()){
 					case AES::ENGINE_OPENSSL:

--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -125,6 +125,17 @@ class BigBrother extends PluginBase implements Listener{
 					break;
 				}
 
+				if($aes->getEngine() === AES::ENGINE_OPENSSL or constant("CRYPT_RSA_MODE") === RSA::MODE_OPENSSL){
+					ob_start();
+					@phpinfo();
+					preg_match_all('#OpenSSL (Header|Library) Version => (.*)#im', ob_get_contents() ?? "", $matches);
+					ob_end_clean();
+
+					foreach(array_map(null, $matches[1], $matches[2]) as $version){
+						$this->getLogger()->info("OpenSSL ".$version[0]." version: ".$version[1]);
+					}
+				}
+
 				if(!$this->getConfig()->exists("motd")){
 					$this->getLogger()->warning("No motd has been set. The server description will be empty.");
 					$this->getPluginLoader()->disablePlugin($this);


### PR DESCRIPTION
## Introduction
We have some issue which is difficult to reproduce.
And there are many combination of prerequisite conditions like below.

* PHP version u are using
* BigBrother version and git revision u are using
* OpenSSL version u are using
  - OpenSSL Header version (When openssl extension is build)
  - OpenSSL Library version (Current OpenSSL version installed in ur system)

And we have to distinguish these conditions.
So, I wrote this PR to make it easy

### Behavioural changes
* No behavioural cahnges (Just print debug info into console)

### Follow-up
Nothing to do
I hope this PR helps ur debug

### Related Issue
* #102 

<!--- Thank you for sending pull-request! -->