### PR TITLE
Refactor the Packet class family

### DIFF
--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -46,6 +46,7 @@ use pocketmine\utils\TextFormat;
 use shoghicp\BigBrother\network\ServerManager;
 use shoghicp\BigBrother\network\ProtocolInterface;
 use shoghicp\BigBrother\network\Translator;
+use shoghicp\BigBrother\network\Packet;
 use shoghicp\BigBrother\network\protocol\Play\Server\RespawnPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\OpenSignEditorPacket;
 use shoghicp\BigBrother\utils\ConvertUtils;
@@ -99,6 +100,7 @@ class BigBrother extends PluginBase implements Listener{
 
 		if($enable){
 			if(Info::CURRENT_PROTOCOL === 354){
+				Packet::init();
 				ConvertUtils::init();
 
 				$this->saveDefaultConfig();

--- a/src/shoghicp/BigBrother/network/Packet.php
+++ b/src/shoghicp/BigBrother/network/Packet.php
@@ -36,6 +36,8 @@ use shoghicp\BigBrother\utils\ComputerItem;
 
 abstract class Packet extends \stdClass{
 
+	const PID = -1;
+
 	/** @var string */
 	protected $buffer;
 	/** @var int */
@@ -226,7 +228,9 @@ abstract class Packet extends \stdClass{
 		$this->buffer .= Binary::writeComputerVarInt($v);
 	}
 
-	public abstract function pid() : int;
+	public function pid() : int{
+		return get_class($this)::PID;
+	}
 
 	protected abstract function encode() : void;
 

--- a/src/shoghicp/BigBrother/network/ProtocolInterface.php
+++ b/src/shoghicp/BigBrother/network/ProtocolInterface.php
@@ -258,38 +258,23 @@ class ProtocolInterface implements SourceInterface{
 			}
 		}
 
-		$pk = Packet::create($pid, $status = $player->bigBrother_getStatus());
-		if($pk !== null){
-			$pk->read($payload, 1);
-		}
+		$packet = Packet::create($pid, $status = $player->bigBrother_getStatus());
+		if($packet !== null){
+			$packet->read($payload, 1);
 
-		switch($status){
-		case 0: //Login
-			switch($pid){
-			case InboundPacket::LOGIN_START_PACKET:
-				$player->bigBrother_handleAuthentication($this->plugin, $pk->name, $this->plugin->isOnlineMode());
+			switch($status){
+			case 0: //Login
+				$player->bigBrother_handleAuthentication($packet);
 				break;
 
-			case InboundPacket::ENCRYPTION_RESPONSE_PACKET:
-				if($this->plugin->isOnlineMode()){
-					$player->bigBrother_processAuthentication($this->plugin, $pk);
-				}
+			case 1: //Play
+				$this->receivePacket($player, $packet);
 				break;
-
-			default:
-				$player->close($player->getLeaveMessage(), "Unexpected packet $pid");
 			}
-			break;
-
-		case 1: //Play
-			if($pk !== null){
-				$this->receivePacket($player, $pk);
-			}else{
-				if(\pocketmine\DEBUG > 4){
-					$this->server->getLogger()->debug("[Receive][Interface] 0x".bin2hex(chr($pid))." Not implemented");
-				}
+		}else{
+			if(\pocketmine\DEBUG > 4){
+				$this->server->getLogger()->debug("[Receive][Interface] 0x".bin2hex(chr($pid))." Not implemented");
 			}
-			break;
 		}
 	}
 

--- a/src/shoghicp/BigBrother/network/ProtocolInterface.php
+++ b/src/shoghicp/BigBrother/network/ProtocolInterface.php
@@ -36,36 +36,6 @@ use pocketmine\Player;
 use pocketmine\utils\MainLogger;
 use shoghicp\BigBrother\BigBrother;
 use shoghicp\BigBrother\DesktopPlayer;
-use shoghicp\BigBrother\network\protocol\Login\EncryptionResponsePacket;
-use shoghicp\BigBrother\network\protocol\Login\LoginStartPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\AdvancementTabPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\EnchantItemPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\TeleportConfirmPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\AnimatePacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\ConfirmTransactionPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\CraftRecipeRequestPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\CraftingBookDataPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\ClickWindowPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\ClientSettingsPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\ClientStatusPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\CreativeInventoryActionPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\EntityActionPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerAbilitiesPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\ChatPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\CloseWindowPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\HeldItemChangePacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\KeepAlivePacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerBlockPlacementPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerDiggingPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerLookPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerPositionAndLookPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PlayerPositionPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\PluginMessagePacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\TabCompletePacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\UpdateSignPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\UseEntityPacket;
-use shoghicp\BigBrother\network\protocol\Play\Client\UseItemPacket;
 use shoghicp\BigBrother\utils\Binary;
 
 class ProtocolInterface implements SourceInterface{
@@ -291,115 +261,40 @@ class ProtocolInterface implements SourceInterface{
 		$pid = ord($payload{0});
 		$offset = 1;
 
-		$status = $player->bigBrother_getStatus();
 
-		if($status === 1){
-			switch($pid){
-				case InboundPacket::TELEPORT_CONFIRM_PACKET:
-					$pk = new TeleportConfirmPacket();
-					break;
-				case InboundPacket::TAB_COMPLETE_PACKET:
-					$pk = new TabCompletePacket();
-					break;
-				case InboundPacket::CHAT_PACKET:
-					$pk = new ChatPacket();
-					break;
-				case InboundPacket::CLIENT_STATUS_PACKET:
-					$pk = new ClientStatusPacket();
-					break;
-				case InboundPacket::CLIENT_SETTINGS_PACKET:
-					$pk = new ClientSettingsPacket();
-					break;
-				case InboundPacket::CONFIRM_TRANSACTION_PACKET:
-					$pk = new ConfirmTransactionPacket();
-					break;
-				case InboundPacket::ENCHANT_ITEM_PACKET:
-					$pk = new EnchantItemPacket();
-					break;
-				case InboundPacket::CLICK_WINDOW_PACKET:
-					$pk = new ClickWindowPacket();
-					break;
-				case InboundPacket::CLOSE_WINDOW_PACKET:
-					$pk = new CloseWindowPacket();
-					break;
-				case InboundPacket::PLUGIN_MESSAGE_PACKET:
-					$pk = new PluginMessagePacket();
-					break;
-				case InboundPacket::USE_ENTITY_PACKET:
-					$pk = new UseEntityPacket();
-					break;
-				case InboundPacket::KEEP_ALIVE_PACKET:
-					$pk = new KeepAlivePacket();
-					break;
-				case InboundPacket::PLAYER_PACKET:
-					$pk = new PlayerPacket();
-					break;
-				case InboundPacket::PLAYER_POSITION_PACKET:
-					$pk = new PlayerPositionPacket();
-					break;
-				case InboundPacket::PLAYER_POSITION_AND_LOOK_PACKET:
-					$pk = new PlayerPositionAndLookPacket();
-					break;
-				case InboundPacket::PLAYER_LOOK_PACKET:
-					$pk = new PlayerLookPacket();
-					break;
-				case InboundPacket::CRAFT_RECIPE_REQUEST_PACKET:
-					$pk = new CraftRecipeRequestPacket();
-				break;
-				case InboundPacket::PLAYER_ABILITIES_PACKET:
-					$pk = new PlayerAbilitiesPacket();
-					break;
-				case InboundPacket::PLAYER_DIGGING_PACKET:
-					$pk = new PlayerDiggingPacket();
-					break;
-				case InboundPacket::ENTITY_ACTION_PACKET:
-					$pk = new EntityActionPacket();
-					break;
-				case InboundPacket::CRAFTING_BOOK_DATA_PACKET:
-					$pk = new CraftingBookDataPacket();
-					break;
-				case InboundPacket::ADVANCEMENT_TAB_PACKET:
-					$pk = new AdvancementTabPacket();
-					break;
-				case InboundPacket::HELD_ITEM_CHANGE_PACKET:
-					$pk = new HeldItemChangePacket();
-					break;
-				case InboundPacket::CREATIVE_INVENTORY_ACTION_PACKET:
-					$pk = new CreativeInventoryActionPacket();
-					break;
-				case InboundPacket::UPDATE_SIGN_PACKET:
-					$pk = new UpdateSignPacket();
-					break;
-				case InboundPacket::ANIMATE_PACKET:
-					$pk = new AnimatePacket();
-					break;
-				case InboundPacket::PLAYER_BLOCK_PLACEMENT_PACKET:
-					$pk = new PlayerBlockPlacementPacket();
-					break;
-				case InboundPacket::USE_ITEM_PACKET:
-					$pk = new UseItemPacket();
-					break;
-				default:
-					if(\pocketmine\DEBUG > 4){
-						echo "[Receive][Interface] 0x".bin2hex(chr($pid))." Not implemented\n"; //Debug
-					}
-					return;
-			}
-
+		$pk = Packet::create($pid, $status = $player->bigBrother_getStatus());
+		if($pk !== null){
 			$pk->read($payload, $offset);
-			$this->receivePacket($player, $pk);
-		}elseif($status === 0){
-			if($pid === InboundPacket::LOGIN_START_PACKET){
-				$pk = new LoginStartPacket();
-				$pk->read($payload, $offset);
+		}
+
+		switch($status){
+		case 0: //Login
+			switch($pid){
+			case InboundPacket::LOGIN_START_PACKET:
 				$player->bigBrother_handleAuthentication($this->plugin, $pk->name, $this->plugin->isOnlineMode());
-			}elseif($pid === InboundPacket::ENCRYPTION_RESPONSE_PACKET and $this->plugin->isOnlineMode()){
-				$pk = new EncryptionResponsePacket();
-				$pk->read($payload, $offset);
-				$player->bigBrother_processAuthentication($this->plugin, $pk);
-			}else{
+				break;
+
+			case InboundPacket::ENCRYPTION_RESPONSE_PACKET:
+				if($this->plugin->isOnlineMode()){
+					$player->bigBrother_processAuthentication($this->plugin, $pk);
+				}
+				break;
+
+			default:
 				$player->close($player->getLeaveMessage(), "Unexpected packet $pid");
 			}
+			break;
+
+		case 1: //Play
+			if($pk !== null){
+				$this->receivePacket($player, $pk);
+			}else{
+				if(\pocketmine\DEBUG > 4){
+					echo "[Receive][Interface] 0x".bin2hex(chr($pid))." Not implemented\n"; //Debug
+				}
+				return;
+			}
+			break;
 		}
 	}
 

--- a/src/shoghicp/BigBrother/network/ProtocolInterface.php
+++ b/src/shoghicp/BigBrother/network/ProtocolInterface.php
@@ -150,9 +150,8 @@ class ProtocolInterface implements SourceInterface{
 	 */
 	protected function sendPacket(int $target, Packet $packet){
 		if(\pocketmine\DEBUG > 4){
-			$id = bin2hex(chr($packet->pid()));
-			if($id !== "1f"){
-				echo "[Send][Interface] 0x".bin2hex(chr($packet->pid()))."\n";
+			if($packet->pid() == OutboundPacket::KEEP_ALIVE_PACKET){
+				$this->server->getLogger()->debug("[Send][Interface] 0x".bin2hex(chr($packet->pid())));
 			}
 		}
 
@@ -251,16 +250,14 @@ class ProtocolInterface implements SourceInterface{
 	 * @param string        $payload
 	 */
 	protected function handlePacket(DesktopPlayer $player, string $payload){
-		if(\pocketmine\DEBUG > 4){
-			$id = bin2hex(chr(ord($payload{0})));
-			if($id !== "0b"){//KeepAlivePacket
-				echo "[Receive][Interface] 0x".bin2hex(chr(ord($payload{0})))."\n";
-			}
-		}
-
 		$pid = ord($payload{0});
 		$offset = 1;
 
+		if(\pocketmine\DEBUG > 4){
+			if($pid == InboundPacket::KEEP_ALIVE_PACKET){
+				$this->server->getLogger()->debug("[Receive][Interface] 0x".bin2hex(chr($pid)));
+			}
+		}
 
 		$pk = Packet::create($pid, $status = $player->bigBrother_getStatus());
 		if($pk !== null){
@@ -290,9 +287,8 @@ class ProtocolInterface implements SourceInterface{
 				$this->receivePacket($player, $pk);
 			}else{
 				if(\pocketmine\DEBUG > 4){
-					echo "[Receive][Interface] 0x".bin2hex(chr($pid))." Not implemented\n"; //Debug
+					$this->server->getLogger()->debug("[Receive][Interface] 0x".bin2hex(chr($pid))." Not implemented");
 				}
-				return;
 			}
 			break;
 		}

--- a/src/shoghicp/BigBrother/network/protocol/Login/EncryptionRequestPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Login/EncryptionRequestPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EncryptionRequestPacket extends OutboundPacket{
 
+	const PID = self::ENCRYPTION_REQUEST_PACKET;
+
 	/** @var string */
 	public $serverID;
 	/** @var string */
 	public $publicKey;
 	/** @var string */
 	public $verifyToken;
-
-	public function pid() : int{
-		return self::ENCRYPTION_REQUEST_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->serverID);

--- a/src/shoghicp/BigBrother/network/protocol/Login/EncryptionResponsePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Login/EncryptionResponsePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class EncryptionResponsePacket extends InboundPacket{
 
+	const PID = self::ENCRYPTION_RESPONSE_PACKET;
+
 	/** @var string */
 	public $sharedSecret;
 	/** @var string */
 	public $verifyToken;
-
-	public function pid() : int{
-		return self::ENCRYPTION_RESPONSE_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->sharedSecret = $this->get($this->getVarInt());

--- a/src/shoghicp/BigBrother/network/protocol/Login/LoginDisconnectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Login/LoginDisconnectPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class LoginDisconnectPacket extends OutboundPacket{
 
+	const PID = self::LOGIN_DISCONNECT_PACKET;
+
 	/** @var string */
 	public $reason;
-
-	public function pid() : int{
-		return self::LOGIN_DISCONNECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->reason);

--- a/src/shoghicp/BigBrother/network/protocol/Login/LoginStartPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Login/LoginStartPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class LoginStartPacket extends InboundPacket{
 
+	const PID = self::LOGIN_START_PACKET;
+
 	/** @var string */
 	public $name;
-
-	public function pid() : int{
-		return self::LOGIN_START_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->name = $this->getString();

--- a/src/shoghicp/BigBrother/network/protocol/Login/LoginSuccessPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Login/LoginSuccessPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class LoginSuccessPacket extends OutboundPacket{
 
+	const PID = self::LOGIN_SUCCESS_PACKET;
+
 	/** @var string */
 	public $uuid;
 	/** @var string */
 	public $name;
-
-	public function pid() : int{
-		return self::LOGIN_SUCCESS_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->uuid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/AdvancementTabPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/AdvancementTabPacket.php
@@ -33,13 +33,11 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class AdvancementTabPacket extends InboundPacket{
 
+	const PID = self::ADVANCEMENT_TAB_PACKET;
+
 	/** @var int  */
 	public $status;
 	public $tabId;
-
-	public function pid() : int{
-		return self::ADVANCEMENT_TAB_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->status = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/AnimatePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/AnimatePacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class AnimatePacket extends InboundPacket{
 
+	const PID = self::ANIMATE_PACKET;
+
 	/** @var int  */
 	public $hand;
-
-	public function pid() : int{
-		return self::ANIMATE_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->hand = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/ChatPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/ChatPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class ChatPacket extends InboundPacket{
 
+	const PID = self::CHAT_PACKET;
+
 	/** @var string */
 	public $message;
-
-	public function pid() : int{
-		return self::CHAT_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->message = $this->getString();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/ClickWindowPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/ClickWindowPacket.php
@@ -34,6 +34,8 @@ use pocketmine\item\Item;
 
 class ClickWindowPacket extends InboundPacket{
 
+	const PID = self::CLICK_WINDOW_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
@@ -46,10 +48,6 @@ class ClickWindowPacket extends InboundPacket{
 	public $mode;
 	/** @var Item */
 	public $clickedItem;
-
-	public function pid() : int{
-		return self::CLICK_WINDOW_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->windowID = $this->getByte();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/ClientSettingsPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/ClientSettingsPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class ClientSettingsPacket extends InboundPacket{
 
+	const PID = self::CLIENT_SETTINGS_PACKET;
+
 	/** @var string */
 	public $lang;
 	/** @var int */
@@ -45,10 +47,6 @@ class ClientSettingsPacket extends InboundPacket{
 	public $skinSetting;
 	/** @var int */
 	public $mainHand;
-
-	public function pid() : int{
-		return self::CLIENT_SETTINGS_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->lang = $this->getString();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/ClientStatusPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/ClientStatusPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class ClientStatusPacket extends InboundPacket{
 
+	const PID = self::CLIENT_STATUS_PACKET;
+
 	/** @var int */
 	public $actionID;
-
-	public function pid() : int{
-		return self::CLIENT_STATUS_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->actionID = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/CloseWindowPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/CloseWindowPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class CloseWindowPacket extends InboundPacket{
 
+	const PID = self::CLOSE_WINDOW_PACKET;
+
 	/** @var int */
 	public $windowID;
-
-	public function pid() : int{
-		return self::CLOSE_WINDOW_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->windowID = $this->getByte();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/ConfirmTransactionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/ConfirmTransactionPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class ConfirmTransactionPacket extends InboundPacket{
 
+	const PID = self::CONFIRM_TRANSACTION_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $actionNumber;
 	/** @var bool */
 	public $accepted;
-
-	public function pid() : int{
-		return self::CONFIRM_TRANSACTION_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->windowID = $this->getSignedByte();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/CraftRecipeRequestPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/CraftRecipeRequestPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class CraftRecipeRequestPacket extends InboundPacket{
 
+	const PID = self::CRAFT_RECIPE_REQUEST_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $recipeId = -1;
 	/** @var bool */
 	public $isMakeAll = false;
-
-	public function pid() : int{
-		return self::CRAFT_RECIPE_REQUEST_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->windowID = $this->getSignedByte();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/CraftingBookDataPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/CraftingBookDataPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class CraftingBookDataPacket extends InboundPacket{
 
+	const PID = self::CRAFTING_BOOK_DATA_PACKET;
+
 	/** @var int */
 	public $type;
 	/** @var int */
@@ -41,10 +43,6 @@ class CraftingBookDataPacket extends InboundPacket{
 	public $isCraftingBookOpen = false;
 	/** @var bool */
 	public $isFilteringCraftable = false;
-
-	public function pid() : int{
-		return self::CRAFTING_BOOK_DATA_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->type = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/CreativeInventoryActionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/CreativeInventoryActionPacket.php
@@ -34,14 +34,12 @@ use pocketmine\item\Item;
 
 class CreativeInventoryActionPacket extends InboundPacket{
 
+	const PID = self::CREATIVE_INVENTORY_ACTION_PACKET;
+
 	/** @var int */
 	public $slot;
 	/** @var Item */
 	public $item;
-
-	public function pid() : int{
-		return self::CREATIVE_INVENTORY_ACTION_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->slot = $this->getSignedShort();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/EnchantItemPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/EnchantItemPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class EnchantItemPacket extends InboundPacket{
 
+	const PID = self::ENCHANT_ITEM_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $enchantment;
-
-	public function pid() : int{
-		return self::ENCHANT_ITEM_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->windowID = $this->getSignedByte();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/EntityActionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/EntityActionPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class EntityActionPacket extends InboundPacket{
 
+	const PID = self::ENTITY_ACTION_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $actionID;
 	/** @var int */
 	public $jumpboost;
-
-	public function pid() : int{
-		return self::ENTITY_ACTION_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->eid = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/HeldItemChangePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/HeldItemChangePacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class HeldItemChangePacket extends InboundPacket{
 
+	const PID = self::HELD_ITEM_CHANGE_PACKET;
+
 	/** @var int */
 	public $selectedSlot;
-
-	public function pid() : int{
-		return self::HELD_ITEM_CHANGE_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->selectedSlot = $this->getSignedShort();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/KeepAlivePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/KeepAlivePacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class KeepAlivePacket extends InboundPacket{
 
+	const PID = self::KEEP_ALIVE_PACKET;
+
 	/** @var int */
 	public $id;
-
-	public function pid() : int{
-		return self::KEEP_ALIVE_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->id = $this->getLong();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerAbilitiesPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerAbilitiesPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerAbilitiesPacket extends InboundPacket{
 
+	const PID = self::PLAYER_ABILITIES_PACKET;
+
 	/** @var bool */
 	public $damageDisabled = false;
 	/** @var bool */
@@ -46,10 +48,6 @@ class PlayerAbilitiesPacket extends InboundPacket{
 	public $flyingSpeed;
 	/** @var float */
 	public $walkingSpeed;
-
-	public function pid() : int{
-		return self::PLAYER_ABILITIES_PACKET;
-	}
 
 	protected function decode() : void{
 		$flags = $this->getSignedByte();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerBlockPlacementPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerBlockPlacementPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerBlockPlacementPacket extends InboundPacket{
 
+	const PID = self::PLAYER_BLOCK_PLACEMENT_PACKET;
+
 	/** @var int */
 	public $x;
 	/** @var int */
@@ -49,10 +51,6 @@ class PlayerBlockPlacementPacket extends InboundPacket{
 	public $cursorY;
 	/** @var float */
 	public $cursorZ;
-
-	public function pid() : int{
-		return self::PLAYER_BLOCK_PLACEMENT_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->getPosition($this->x, $this->y, $this->z);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerDiggingPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerDiggingPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerDiggingPacket extends InboundPacket{
 
+	const PID = self::PLAYER_DIGGING_PACKET;
+
 	/** @var int */
 	public $status;
 	/** @var int */
@@ -43,10 +45,6 @@ class PlayerDiggingPacket extends InboundPacket{
 	public $z;
 	/** @var int */
 	public $face;
-
-	public function pid() : int{
-		return self::PLAYER_DIGGING_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->status = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerLookPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerLookPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerLookPacket extends InboundPacket{
 
+	const PID = self::PLAYER_LOOK_PACKET;
+
 	/** @var float */
 	public $yaw;
 	/** @var float */
 	public $pitch;
 	/** @var bool */
 	public $onGround;
-
-	public function pid() : int{
-		return self::PLAYER_LOOK_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->yaw = $this->getFloat();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerPacket extends InboundPacket{
 
+	const PID = self::PLAYER_PACKET;
+
 	/** @var bool */
 	public $onGround;
-
-	public function pid() : int{
-		return self::PLAYER_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->onGround = $this->getBool();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerPositionAndLookPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerPositionAndLookPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerPositionAndLookPacket extends InboundPacket{
 
+	const PID = self::PLAYER_POSITION_AND_LOOK_PACKET;
+
 	/** @var float */
 	public $x;
 	/** @var float */
@@ -45,10 +47,6 @@ class PlayerPositionAndLookPacket extends InboundPacket{
 	public $pitch;
 	/** @var bool */
 	public $onGround;
-
-	public function pid() : int{
-		return self::PLAYER_POSITION_AND_LOOK_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->x = $this->getDouble();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerPositionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PlayerPositionPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PlayerPositionPacket extends InboundPacket{
 
+	const PID = self::PLAYER_POSITION_PACKET;
+
 	/** @var float */
 	public $x;
 	/** @var float */
@@ -41,10 +43,6 @@ class PlayerPositionPacket extends InboundPacket{
 	public $z;
 	/** @var bool */
 	public $onGround;
-
-	public function pid() : int{
-		return self::PLAYER_POSITION_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->x = $this->getDouble();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/PluginMessagePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/PluginMessagePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class PluginMessagePacket extends InboundPacket{
 
+	const PID = self::PLUGIN_MESSAGE_PACKET;
+
 	/** @var string */
 	public $channel;
 	/** @var string[] */
 	public $data = [];
-
-	public function pid() : int{
-		return self::PLUGIN_MESSAGE_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->channel = $this->getString();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/TabCompletePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/TabCompletePacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class TabCompletePacket extends InboundPacket{
 
+	const PID = self::TAB_COMPLETE_PACKET;
+
 	/** @var string */
 	public $text;
 	/** @var bool */
@@ -45,10 +47,6 @@ class TabCompletePacket extends InboundPacket{
 	public $y;
 	/** @var int */
 	public $z;
-
-	public function pid() : int{
-		return self::TAB_COMPLETE_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->text = $this->getString();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/TeleportConfirmPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/TeleportConfirmPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class TeleportConfirmPacket extends InboundPacket{
 
+	const PID = self::TELEPORT_CONFIRM_PACKET;
+
 	/** @var int */
 	public $teleportId;
-
-	public function pid() : int{
-		return self::TELEPORT_CONFIRM_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->teleportId = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/UpdateSignPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/UpdateSignPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class UpdateSignPacket extends InboundPacket{
 
+	const PID = self::UPDATE_SIGN_PACKET;
+
 	/** @var int */
 	public $x;
 	/** @var int */
@@ -47,10 +49,6 @@ class UpdateSignPacket extends InboundPacket{
 	public $line3;
 	/** @var string */
 	public $line4;
-
-	public function pid() : int{
-		return self::UPDATE_SIGN_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->getPosition($this->x, $this->y, $this->z);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/UseEntityPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/UseEntityPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class UseEntityPacket extends InboundPacket{
 
+	const PID = self::USE_ENTITY_PACKET;
+
 	const INTERACT    = 0;
 	const ATTACK      = 1;
 	const INTERACT_AT = 2;
@@ -51,10 +53,6 @@ class UseEntityPacket extends InboundPacket{
 
 	/** @var int */
 	public $hand;
-
-	public function pid() : int{
-		return self::USE_ENTITY_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->target = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Client/UseItemPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Client/UseItemPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\InboundPacket;
 
 class UseItemPacket extends InboundPacket{
 
+	const PID = self::USE_ITEM_PACKET;
+
 	/** @var int */
 	public $hand;
-
-	public function pid() : int{
-		return self::USE_ITEM_PACKET;
-	}
 
 	protected function decode() : void{
 		$this->hand = $this->getVarInt();

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/AdvancementsPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/AdvancementsPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class AdvancementsPacket extends OutboundPacket{
 
+	const PID = self::ADVANCEMENTS_PACKET;
+
 	/** @var bool */
 	public $doClear = false;
 	/** @var array */
@@ -41,10 +43,6 @@ class AdvancementsPacket extends OutboundPacket{
 	public $identifiers = [];
 	/** @var array */
 	public $progress = [];
-
-	public function pid() : int{
-		return self::ADVANCEMENTS_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putBool($this->doClear);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/AnimatePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/AnimatePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class AnimatePacket extends OutboundPacket{
 
+	const PID = self::ANIMATE_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $actionID;
-
-	public function pid() : int{
-		return self::ANIMATE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/BlockActionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/BlockActionPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class BlockActionPacket extends OutboundPacket{
 
+	const PID = self::BLOCK_ACTION_PACKET;
+
 	/** @var int */
 	public $x;
 	/** @var int */
@@ -45,10 +47,6 @@ class BlockActionPacket extends OutboundPacket{
 	public $actionParam;
 	/** @var int */
 	public $blockType;
-
-	public function pid() : int{
-		return self::BLOCK_ACTION_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putPosition($this->x, $this->y, $this->z);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/BlockBreakAnimationPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/BlockBreakAnimationPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class BlockBreakAnimationPacket extends OutboundPacket{
 
+	const PID = self::BLOCK_BREAK_ANIMATION_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
@@ -43,10 +45,6 @@ class BlockBreakAnimationPacket extends OutboundPacket{
 	public $z;
 	/** @var int */
 	public $destroyStage;
-
-	public function pid() : int{
-		return self::BLOCK_BREAK_ANIMATION_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/BlockChangePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/BlockChangePacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class BlockChangePacket extends OutboundPacket{
 
+	const PID = self::BLOCK_CHANGE_PACKET;
+
 	/** @var int */
 	public $x;
 	/** @var int */
@@ -43,10 +45,6 @@ class BlockChangePacket extends OutboundPacket{
 	public $blockId;
 	/** @var int */
 	public $blockMeta;
-
-	public function pid() : int{
-		return self::BLOCK_CHANGE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putPosition($this->x, $this->y, $this->z);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/BossBarPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/BossBarPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class BossBarPacket extends OutboundPacket{
 
+	const PID = self::BOSS_BAR_PACKET;
+
 	const TYPE_ADD = 0;
 	const TYPE_REMOVE = 1;
 	const TYPE_UPDATE_HEALTH = 2;
@@ -77,10 +79,6 @@ class BossBarPacket extends OutboundPacket{
 	public $division = self::DIVISION_ZERO;
 	/** @var int */
 	public $flags = 0;
-
-	public function pid() : int{
-		return self::BOSS_BAR_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->put($this->uuid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ChangeGameStatePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ChangeGameStatePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class ChangeGameStatePacket extends OutboundPacket{
 
+	const PID = self::CHANGE_GAME_STATE_PACKET;
+
 	/** @var int */
 	public $reason;
 	/** @var float */
 	public $value;
-
-	public function pid() : int{
-		return self::CHANGE_GAME_STATE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->reason);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ChatPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ChatPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class ChatPacket extends OutboundPacket{
 
+	const PID = self::CHAT_PACKET;
+
 	/** @var string */
 	public $message;
 	/** @var int */
 	public $position = 0; //0 = chat, 1 = system message, 2 = action bar
-
-	public function pid() : int{
-		return self::CHAT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->message);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ChunkDataPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ChunkDataPacket.php
@@ -39,6 +39,8 @@ use pocketmine\nbt\tag\ShortTag;
 
 class ChunkDataPacket extends OutboundPacket{
 
+	const PID = self::CHUNK_DATA_PACKET;
+
 	/** @var int */
 	public $chunkX;
 	/** @var int */
@@ -53,10 +55,6 @@ class ChunkDataPacket extends OutboundPacket{
 	public $biomes;
 	/** @var array */
 	public $blockEntities = [];
-
-	public function pid() : int{
-		return self::CHUNK_DATA_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->chunkX);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/CloseWindowPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/CloseWindowPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class CloseWindowPacket extends OutboundPacket{
 
+	const PID = self::CLOSE_WINDOW_PACKET;
+
 	/** @var int */
 	public $windowID;
-
-	public function pid() : int{
-		return self::CLOSE_WINDOW_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/CollectItemPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/CollectItemPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class CollectItemPacket extends OutboundPacket{
 
+	const PID = self::COLLECT_ITEM_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $target;
 	/** @var int */
 	public $itemCount;
-
-	public function pid() : int{
-		return self::COLLECT_ITEM_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->target);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ConfirmTransactionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ConfirmTransactionPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class ConfirmTransactionPacket extends OutboundPacket{
 
+	const PID = self::CONFIRM_TRANSACTION_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $actionNumber;
 	/** @var bool */
 	public $accepted;
-
-	public function pid() : int{
-		return self::CONFIRM_TRANSACTION_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/CraftRecipeResponsePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/CraftRecipeResponsePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class CraftRecipeResponsePacket extends OutboundPacket{
 
+	const PID = self::CRAFT_RECIPE_RESPONSE_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $recipeId = -1;
-
-	public function pid() : int{
-		return self::CRAFT_RECIPE_RESPONSE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/DestroyEntitiesPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/DestroyEntitiesPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class DestroyEntitiesPacket extends OutboundPacket{
 
+	const PID = self::DESTROY_ENTITIES_PACKET;
+
 	/** @var int[] */
 	public $ids = [];
-
-	public function pid() : int{
-		return self::DESTROY_ENTITIES_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt(count($this->ids));

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EffectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EffectPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EffectPacket extends OutboundPacket{
 
+	const PID = self::EFFECT_PACKET;
+
 	/** @var int */
 	public $effectId;
 	/** @var int */
@@ -45,10 +47,6 @@ class EffectPacket extends OutboundPacket{
 	public $data;
 	/** @var bool */
 	public $disableRelativeVolume;
-
-	public function pid() : int{
-		return self::EFFECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->effectId);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityEffectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityEffectPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityEffectPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_EFFECT_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
@@ -43,10 +45,6 @@ class EntityEffectPacket extends OutboundPacket{
 	public $duration;
 	/** @var int */
 	public $flags;
-
-	public function pid() : int{
-		return self::ENTITY_EFFECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityEquipmentPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityEquipmentPacket.php
@@ -34,16 +34,14 @@ use pocketmine\item\Item;
 
 class EntityEquipmentPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_EQUIPMENT_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $slot;
 	/** @var Item */
 	public $item;
-
-	public function pid() : int{
-		return self::ENTITY_EQUIPMENT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityHeadLookPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityHeadLookPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityHeadLookPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_HEAD_LOOK_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $yaw;
-
-	public function pid() : int{
-		return self::ENTITY_HEAD_LOOK_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityLookPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityLookPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityLookPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_LOOK_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
@@ -41,10 +43,6 @@ class EntityLookPacket extends OutboundPacket{
 	public $pitch;
 	/** @var bool */
 	public $onGround;
-
-	public function pid() : int{
-		return self::ENTITY_LOOK_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityMetadataPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityMetadataPacket.php
@@ -34,14 +34,12 @@ use shoghicp\BigBrother\utils\Binary;
 
 class EntityMetadataPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_METADATA_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var array */
 	public $metadata;
-
-	public function pid() : int{
-		return self::ENTITY_METADATA_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_PACKET;
+
 	/** @var int */
 	public $eid;
-
-	public function pid() : int{
-		return self::ENTITY_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityPropertiesPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityPropertiesPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityPropertiesPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_PROPERTIES_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var array */
 	public $entries = [];
-
-	public function pid() : int{
-		return self::ENTITY_PROPERTIES_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityStatusPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityStatusPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityStatusPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_STATUS_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $status;
-
-	public function pid() : int{
-		return self::ENTITY_STATUS_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityTeleportPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityTeleportPacket.php
@@ -32,6 +32,9 @@ namespace shoghicp\BigBrother\network\protocol\Play\Server;
 use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityTeleportPacket extends OutboundPacket{
+
+	const PID = self::ENTITY_TELEPORT_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var float */
@@ -46,10 +49,6 @@ class EntityTeleportPacket extends OutboundPacket{
 	public $pitch;
 	/** @var bool */
 	public $onGround = true;
-
-	public function pid() : int{
-		return self::ENTITY_TELEPORT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityVelocityPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/EntityVelocityPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class EntityVelocityPacket extends OutboundPacket{
 
+	const PID = self::ENTITY_VELOCITY_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var float */
@@ -41,10 +43,6 @@ class EntityVelocityPacket extends OutboundPacket{
 	public $velocityY;
 	/** @var float */
 	public $velocityZ;
-
-	public function pid() : int{
-		return self::ENTITY_VELOCITY_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ExplosionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ExplosionPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class ExplosionPacket extends OutboundPacket{
 
+	const PID = self::EXPLOSION_PACKET;
+
 	/** @var float */
 	public $x;
 	/** @var float */
@@ -49,10 +51,6 @@ class ExplosionPacket extends OutboundPacket{
 	public $motionY;
 	/** @var float */
 	public $motionZ;
-
-	public function pid() : int{
-		return self::EXPLOSION_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putFloat($this->x);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/HeldItemChangePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/HeldItemChangePacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class HeldItemChangePacket extends OutboundPacket{
 
+	const PID = self::HELD_ITEM_CHANGE_PACKET;
+
 	/** @var int */
 	public $selectedSlot;
-
-	public function pid() : int{
-		return self::HELD_ITEM_CHANGE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->selectedSlot);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/JoinGamePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/JoinGamePacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class JoinGamePacket extends OutboundPacket{
 
+	const PID = self::JOIN_GAME_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
@@ -47,10 +49,6 @@ class JoinGamePacket extends OutboundPacket{
 	public $levelType;
 	/** @var bool */
 	public $reducedDebugInfo = false;
-
-	public function pid() : int{
-		return self::JOIN_GAME_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/KeepAlivePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/KeepAlivePacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class KeepAlivePacket extends OutboundPacket{
 
+	const PID = self::KEEP_ALIVE_PACKET;
+
 	/** @var int */
 	public $id;
-
-	public function pid() : int{
-		return self::KEEP_ALIVE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putLong($this->id);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/NamedSoundEffectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/NamedSoundEffectPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class NamedSoundEffectPacket extends OutboundPacket{
 
+	const PID = self::NAMED_SOUND_EFFECT_PACKET;
+
 	/** @var string */
 	public $name;
 	/** @var int */
@@ -47,10 +49,6 @@ class NamedSoundEffectPacket extends OutboundPacket{
 	public $volume;
 	/** @var float */
 	public $pitch;
-
-	public function pid() : int{
-		return self::NAMED_SOUND_EFFECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->name);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/OpenSignEditorPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/OpenSignEditorPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class OpenSignEditorPacket extends OutboundPacket{
 
+	const PID = self::OPEN_SIGN_EDITOR_PACKET;
+
 	/** @var int */
 	public $x;
 	/** @var int */
 	public $y;
 	/** @var int */
 	public $z;
-
-	public function pid() : int{
-		return self::OPEN_SIGN_EDITOR_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putPosition($this->x, $this->y, $this->z);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/OpenWindowPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/OpenWindowPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class OpenWindowPacket extends OutboundPacket{
 
+	const PID = self::OPEN_WINDOW_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var string */
@@ -43,10 +45,6 @@ class OpenWindowPacket extends OutboundPacket{
 	public $slots;
 	/** @var int */
 	public $entityId = -1;
-
-	public function pid() : int{
-		return self::OPEN_WINDOW_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ParticlePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ParticlePacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class ParticlePacket extends OutboundPacket{
 
+	const PID = self::PARTICLE_PACKET;
+
 	/** @var int */
 	public $id;
 	/** @var bool */
@@ -55,10 +57,6 @@ class ParticlePacket extends OutboundPacket{
 	public $count;
 	/** @var array */
 	public $addData = [];
-
-	public function pid() : int{
-		return self::PARTICLE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->id);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayDisconnectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayDisconnectPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class PlayDisconnectPacket extends OutboundPacket{
 
+	const PID = self::PLAY_DISCONNECT_PACKET;
+
 	/** @var string */
 	public $reason;
-
-	public function pid() : int{
-		return self::PLAY_DISCONNECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->reason);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayerAbilitiesPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayerAbilitiesPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class PlayerAbilitiesPacket extends OutboundPacket{
 
+	const PID = self::PLAYER_ABILITIES_PACKET;
+
 	/** @var bool */
 	public $damageDisabled;
 	/** @var bool */
@@ -46,10 +48,6 @@ class PlayerAbilitiesPacket extends OutboundPacket{
 	public $flyingSpeed;
 	/** @var float */
 	public $walkingSpeed;
-
-	public function pid() : int{
-		return self::PLAYER_ABILITIES_PACKET;
-	}
 
 	protected function encode() : void{
 		$flags = 0;

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayerListPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayerListPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class PlayerListPacket extends OutboundPacket{
 
+	const PID = self::PLAYER_LIST_PACKET;
+
 	const TYPE_ADD = 0;
 	const TYPE_UPDATE_NAME = 3;
 	const TYPE_REMOVE = 4;
@@ -41,10 +43,6 @@ class PlayerListPacket extends OutboundPacket{
 	public $actionID;
 	/** @var array */
 	public $players = [];
-
-	public function pid() : int{
-		return self::PLAYER_LIST_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->actionID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayerPositionAndLookPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/PlayerPositionAndLookPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class PlayerPositionAndLookPacket extends OutboundPacket{
 
+	const PID = self::PLAYER_POSITION_AND_LOOK_PACKET;
+
 	/** @var float */
 	public $x;
 	/** @var float */
@@ -47,10 +49,6 @@ class PlayerPositionAndLookPacket extends OutboundPacket{
 	public $flags = 0;
 	/** @var int */
 	public $teleportId = 0;
-
-	public function pid() : int{
-		return self::PLAYER_POSITION_AND_LOOK_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putDouble($this->x);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/PluginMessagePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/PluginMessagePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class PluginMessagePacket extends OutboundPacket{
 
+	const PID = self::PLUGIN_MESSAGE_PACKET;
+
 	/** @var string */
 	public $channel;
 	/** @var array */
 	public $data = [];
-
-	public function pid() : int{
-		return self::PLUGIN_MESSAGE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putString($this->channel);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/RemoveEntityEffectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/RemoveEntityEffectPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class RemoveEntityEffectPacket extends OutboundPacket{
 
+	const PID = self::REMOVE_ENTITY_EFFECT_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
 	public $effectId;
-
-	public function pid() : int{
-		return self::REMOVE_ENTITY_EFFECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/RespawnPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/RespawnPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class RespawnPacket extends OutboundPacket{
 
+	const PID = self::RESPAWN_PACKET;
+
 	/** @var int */
 	public $dimension;
 	/** @var int */
@@ -41,10 +43,6 @@ class RespawnPacket extends OutboundPacket{
 	public $gamemode;
 	/** @var string */
 	public $levelType;
-
-	public function pid() : int{
-		return self::RESPAWN_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->dimension);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SelectAdvancementTabPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SelectAdvancementTabPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SelectAdvancementTabPacket extends OutboundPacket{
 
+	const PID = self::SELECT_ADVANCEMENT_TAB_PACKET;
+
 	/** @var bool */
 	public $hasTab = false;
 	/** @var string */
 	public $tabId = "";
-
-	public function pid() : int{
-		return self::SELECT_ADVANCEMENT_TAB_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putBool($this->hasTab);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/ServerDifficultyPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/ServerDifficultyPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class ServerDifficultyPacket extends OutboundPacket{
 
+	const PID = self::SERVER_DIFFICULTY_PACKET;
+
 	/** @var int */
 	public $difficulty;
-
-	public function pid() : int{
-		return self::SERVER_DIFFICULTY_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->difficulty);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SetExperiencePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SetExperiencePacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SetExperiencePacket extends OutboundPacket{
 
+	const PID = self::SET_EXPERIENCE_PACKET;
+
 	/** @var float */
 	public $experience;
 	/** @var int */
 	public $level;
 	/** @var int */
 	public $totalexperience;
-
-	public function pid() : int{
-		return self::SET_EXPERIENCE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putFloat($this->experience);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SetSlotPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SetSlotPacket.php
@@ -34,16 +34,14 @@ use pocketmine\item\Item;
 
 class SetSlotPacket extends OutboundPacket{
 
+	const PID = self::SET_SLOT_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $slot;
 	/** @var Item */
 	public $item;
-
-	public function pid() : int{
-		return self::SET_SLOT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SoundEffectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SoundEffectPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SoundEffectPacket extends OutboundPacket{
 
+	const PID = self::SOUND_EFFECT_PACKET;
+
 	/** @var int */
 	public $id;
 	/** @var int */
@@ -47,10 +49,6 @@ class SoundEffectPacket extends OutboundPacket{
 	public $volume;
 	/** @var float */
 	public $pitch;
-
-	public function pid() : int{
-		return self::SOUND_EFFECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->id);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnExperienceOrbPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnExperienceOrbPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SpawnExperienceOrbPacket extends OutboundPacket{
 
+	const PID = self::SPAWN_EXPERIENCE_ORB_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var float */
@@ -43,10 +45,6 @@ class SpawnExperienceOrbPacket extends OutboundPacket{
 	public $z;
 	/** @var int */
 	public $count;
-
-	public function pid() : int{
-		return self::SPAWN_EXPERIENCE_ORB_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnMobPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnMobPacket.php
@@ -34,6 +34,8 @@ use shoghicp\BigBrother\utils\Binary;
 
 class SpawnMobPacket extends OutboundPacket{
 
+	const PID = self::SPAWN_MOB_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var string */
@@ -60,10 +62,6 @@ class SpawnMobPacket extends OutboundPacket{
 	public $velocityZ;
 	/** @var array */
 	public $metadata;
-
-	public function pid() : int{
-		return self::SPAWN_MOB_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnObjectPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnObjectPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SpawnObjectPacket extends OutboundPacket{
 
+	const PID = self::SPAWN_OBJECT_PACKET;
+
 	const BOAT              =  1;
 	const ITEM_STACK        =  2;
 	const AREA_EFFECT_CLOUD =  3;
@@ -87,10 +89,6 @@ class SpawnObjectPacket extends OutboundPacket{
 	public $velocityY;
 	/** @var float */
 	public $velocityZ;
-
-	public function pid() : int{
-		return self::SPAWN_OBJECT_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnPaintingPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnPaintingPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SpawnPaintingPacket extends OutboundPacket{
 
+	const PID = self::SPAWN_PAINTING_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var string */
@@ -48,11 +50,6 @@ class SpawnPaintingPacket extends OutboundPacket{
 	/** @var int */
 	public $direction;
 	
-
-	public function pid() : int{
-		return self::SPAWN_PAINTING_PACKET;
-	}
-
 	protected function encode() : void{
 		$this->putVarInt($this->eid);
 		$this->put($this->uuid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnPlayerPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnPlayerPacket.php
@@ -34,6 +34,8 @@ use shoghicp\BigBrother\utils\Binary;
 
 class SpawnPlayerPacket extends OutboundPacket{
 
+	const PID = self::SPAWN_PLAYER_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var string */
@@ -50,10 +52,6 @@ class SpawnPlayerPacket extends OutboundPacket{
 	public $pitch;
 	/** @var array */
 	public $metadata;
-
-	public function pid() : int{
-		return self::SPAWN_PLAYER_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnPositionPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnPositionPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class SpawnPositionPacket extends OutboundPacket{
 
+	const PID = self::SPAWN_POSITION_PACKET;
+
 	/** @var int */
 	public $spawnX;
 	/** @var int */
 	public $spawnY;
 	/** @var int */
 	public $spawnZ;
-
-	public function pid() : int{
-		return self::SPAWN_POSITION_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putPosition($this->spawnX, $this->spawnY, $this->spawnZ);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/StatisticsPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/StatisticsPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class StatisticsPacket extends OutboundPacket{
 
+	const PID = self::STATISTICS_PACKET;
+
 	/** @var int */
 	public $count;
 	/** @var array */
 	public $statistic = [];
-
-	public function pid() : int{
-		return self::STATISTICS_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->count);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/TabCompletePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/TabCompletePacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class TabCompletePacket extends OutboundPacket{
 
+	const PID = self::TAB_COMPLETE_PACKET;
+
 	/** @var string[] */
 	public $matches = [];
-
-	public function pid() : int{
-		return self::TAB_COMPLETE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt(count($this->matches));

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/TimeUpdatePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/TimeUpdatePacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class TimeUpdatePacket extends OutboundPacket{
 
+	const PID = self::TIME_UPDATE_PACKET;
+
 	/** @var int */
 	public $age;
 	/** @var int */
 	public $time;
-
-	public function pid() : int{
-		return self::TIME_UPDATE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putLong($this->age);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/TitlePacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/TitlePacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class TitlePacket extends OutboundPacket{
 
+	const PID = self::TITLE_PACKET;
+
 	const TYPE_SET_TITLE = 0;
 	const TYPE_SET_SUB_TITLE = 1;
 	const TYPE_SET_ACTION_BAR = 2;
@@ -44,10 +46,6 @@ class TitlePacket extends OutboundPacket{
 	public $actionID;
 	/** @var string|int[] */
 	public $data = null;
-
-	public function pid() : int{
-		return self::TITLE_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->actionID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/UnloadChunkPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/UnloadChunkPacket.php
@@ -33,14 +33,12 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class UnloadChunkPacket extends OutboundPacket{
 
+	const PID = self::UNLOAD_CHUNK_PACKET;
+
 	/** @var int */
 	public $chunkX;
 	/** @var int */
 	public $chunkZ;
-
-	public function pid() : int{
-		return self::UNLOAD_CHUNK_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putInt($this->chunkX);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/UnlockRecipesPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/UnlockRecipesPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class UnlockRecipesPacket extends OutboundPacket{
 
+	const PID = self::UNLOCK_RECIPES_PACKET;
+
 	/** @var int */
 	public $actionID;
 	/** @var bool */
@@ -43,10 +45,6 @@ class UnlockRecipesPacket extends OutboundPacket{
 	public $recipes = [];
 	/** @var int[] */
 	public $extraRecipes = [];
-
-	public function pid() : int{
-		return self::UNLOCK_RECIPES_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->actionID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/UpdateBlockEntityPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/UpdateBlockEntityPacket.php
@@ -35,6 +35,8 @@ use pocketmine\nbt\tag\NamedTag;
 
 class UpdateBlockEntityPacket extends OutboundPacket{
 
+	const PID = self::UPDATE_BLOCK_ENTITY_PACKET;
+
 	/** @var int */
 	public $x;
 	/** @var int */
@@ -45,10 +47,6 @@ class UpdateBlockEntityPacket extends OutboundPacket{
 	public $actionID;
 	/** @var NamedTag */
 	public $namedtag;
-
-	public function pid() : int{
-		return self::UPDATE_BLOCK_ENTITY_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putPosition($this->x, $this->y, $this->z);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/UpdateHealthPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/UpdateHealthPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class UpdateHealthPacket extends OutboundPacket{
 
+	const PID = self::UPDATE_HEALTH_PACKET;
+
 	/** @var float */
 	public $health;
 	/** @var int */
 	public $food;
 	/** @var float */
 	public $saturation;
-
-	public function pid() : int{
-		return self::UPDATE_HEALTH_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putFloat($this->health);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/UseBedPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/UseBedPacket.php
@@ -33,6 +33,8 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class UseBedPacket extends OutboundPacket{
 
+	const PID = self::USE_BED_PACKET;
+
 	/** @var int */
 	public $eid;
 	/** @var int */
@@ -41,10 +43,6 @@ class UseBedPacket extends OutboundPacket{
 	public $bedY;
 	/** @var int */
 	public $bedZ;
-
-	public function pid() : int{
-		return self::USE_BED_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putVarInt($this->eid);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/WindowItemsPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/WindowItemsPacket.php
@@ -34,14 +34,12 @@ use pocketmine\item\Item;
 
 class WindowItemsPacket extends OutboundPacket{
 
+	const PID = self::WINDOW_ITEMS_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var Item[] */
 	public $items = [];
-
-	public function pid() : int{
-		return self::WINDOW_ITEMS_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/WindowPropertyPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/WindowPropertyPacket.php
@@ -33,16 +33,14 @@ use shoghicp\BigBrother\network\OutboundPacket;
 
 class WindowPropertyPacket extends OutboundPacket{
 
+	const PID = self::WINDOW_PROPERTY_PACKET;
+
 	/** @var int */
 	public $windowID;
 	/** @var int */
 	public $property;
 	/** @var int */
 	public $value;
-
-	public function pid() : int{
-		return self::WINDOW_PROPERTY_PACKET;
-	}
 
 	protected function encode() : void{
 		$this->putByte($this->windowID);

--- a/src/shoghicp/BigBrother/network/protocol/Status/PingPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Status/PingPacket.php
@@ -33,12 +33,10 @@ use shoghicp\BigBrother\network\Packet;
 
 class PingPacket extends Packet{
 
+	const PID = 0x01;
+
 	/** @var int */
 	public $time;
-
-	public function pid() : int{
-		return 0x01;
-	}
 
 	protected function encode() : void{
 		$this->putLong($this->time);


### PR DESCRIPTION
## Introduction
I know that this change-set do nothing, and this is not productive change-set.
And also know that  there were similar patch in the past which had rejected.
Though, I'll try to refactor the `Packet` class family and `ProtocolInterface` class again!

### Behavioural changes
* Nothing

### Design Changes
* Automatically generate class-map of `Packet` class family when plugin is enabled (startup)
* Implement the packet creation method from status, packet direction, and pid
 From now on, we don't need to call constructor of specific class to instantiate packet.
 And no need to declare `use` statement to import namespaces.
* Refactor the `ProtocolInterface` class to simplify it
 Just use interface of `Packet` class, no need to call constructor or method which depends on specific classes.

#### PROS
*  We don't need to take care about the `use` statement omission for each specialized packet class implementation.
* And also we don't need to instantiate for each specialized packet class explicitly
* All of specialized Packet class is pre-loaded when plugin is loaded, it may increase performance of packet instantiation
* The code is fewer  than before and clean
* Easy to maintain

#### CONS
* Bit complicate

### Follow-up
This is just my proposal refactoring implementation.
So, we may need to discuss or consider well about the design.

<!--- Thank you for sending pull-request! -->