### PR TITLE
add SpawnGlobalEntityPacket class to support lightning (thunder)

### DIFF
--- a/src/shoghicp/BigBrother/network/OutboundPacket.php
+++ b/src/shoghicp/BigBrother/network/OutboundPacket.php
@@ -34,7 +34,7 @@ abstract class OutboundPacket extends Packet{
 	//Play
 	const SPAWN_OBJECT_PACKET = 0x00;
 	const SPAWN_EXPERIENCE_ORB_PACKET = 0x01;
-	//TODO SPAWN_GLOBAL_ENTITY_PACKET = 0x02;
+	const SPAWN_GLOBAL_ENTITY_PACKET = 0x02;
 	const SPAWN_MOB_PACKET = 0x03;
 	const SPAWN_PAINTING_PACKET = 0x04;
 	const SPAWN_PLAYER_PACKET = 0x05;

--- a/src/shoghicp/BigBrother/network/Translator.php
+++ b/src/shoghicp/BigBrother/network/Translator.php
@@ -143,6 +143,7 @@ use shoghicp\BigBrother\network\protocol\Play\Server\RespawnPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\SelectAdvancementTabPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\ServerDifficultyPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\SetExperiencePacket;
+use shoghicp\BigBrother\network\protocol\Play\Server\SpawnGlobalEntityPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\SpawnExperienceOrbPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\SpawnMobPacket;
 use shoghicp\BigBrother\network\protocol\Play\Server\SpawnObjectPacket;
@@ -1280,10 +1281,16 @@ class Translator{
 					case 90;//Boat
 						$packet->type = 1;
 					break;
-					/*case 93://Lightning
-						//Spawn Global Entity
+					case 93://Lightning
+						$pk = new SpawnGlobalEntityPacket();
+						$pk->eid = $packet->entityRuntimeId;
+						$pk->type = SpawnGlobalEntityPacket::TYPE_LIGHTNING;
+						$pk->x = $packet->position->x;
+						$pk->y = $packet->position->y;
+						$pk->z = $packet->position->z;
+						return $pk;
 					break;
-					case 94://BlazeFireball
+					/*case 94://BlazeFireball
 						//Spawn Object
 					break;
 					case 96://MinecartHopper

--- a/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnGlobalEntityPacket.php
+++ b/src/shoghicp/BigBrother/network/protocol/Play/Server/SpawnGlobalEntityPacket.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *  ______  __         ______               __    __
+ * |   __ \|__|.-----.|   __ \.----..-----.|  |_ |  |--..-----..----.
+ * |   __ <|  ||  _  ||   __ <|   _||  _  ||   _||     ||  -__||   _|
+ * |______/|__||___  ||______/|__|  |_____||____||__|__||_____||__|
+ *             |_____|
+ *
+ * BigBrother plugin for PocketMine-MP
+ * Copyright (C) 2014-2015 shoghicp <https://github.com/shoghicp/BigBrother>
+ * Copyright (C) 2016- BigBrotherTeam
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @author BigBrotherTeam
+ * @link   https://github.com/BigBrotherTeam/BigBrother
+ *
+ */
+
+declare(strict_types=1);
+
+namespace shoghicp\BigBrother\network\protocol\Play\Server;
+
+use shoghicp\BigBrother\network\OutboundPacket;
+
+class SpawnGlobalEntityPacket extends OutboundPacket{
+
+	const TYPE_LIGHTNING = 1;
+
+	/** @var int */
+	public $eid;
+	/** @var int */
+	public $type;
+	/** @var float */
+	public $x;
+	/** @var float */
+	public $y;
+	/** @var float */
+	public $z;
+	/** @var int */
+
+	public function pid() : int{
+		return self::SPAWN_GLOBAL_ENTITY_PACKET;
+	}
+
+	protected function encode() : void{
+		$this->putVarInt($this->eid);
+		$this->putByte($this->type);
+		$this->putDouble($this->x);
+		$this->putDouble($this->y);
+		$this->putDouble($this->z);
+	}
+}


### PR DESCRIPTION
## Introduction
Implement missing SpawnGlobalEntityPacket class for handling spawn lightning.
Since, PMMP not supporting the weather we need to confirm this behavior with plugin such as Lightning_Strike.

### Behavioural changes
* From now on, lightning (thunder) appear

### Follow-up
Nothing, this is very simple change

<!--- Thank you for sending pull-request! -->