### PR TITLE
support Travis-CI and Bintray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 
-dists/
+build/
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 build/
 vendor/
+resources/revision

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+git:
+  depth: false
+
 php:
   - 7.2
   - 7.3
@@ -16,3 +19,16 @@ before_script:
 
 script:
   - composer build
+
+before_deploy:
+  - scripts/before_deploy
+
+deploy:
+  provider: bintray
+  user: ${BINTRAY_USER}
+  key: ${BINTRAY_SECRET}
+  skip_cleanup: true
+  on:
+    all_branches: true
+    condition: $TRAVIS_PHP_VERSION = 7.2
+  file: build/bintray.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 before_script:
   - echo | pecl install channel://pecl.php.net/yaml-2.0.4
   - find src/ -type f -name '*.php' | xargs -n 1 php -l
+  - composer config -g github-oauth.github.com ${GITHUB_OAUTH_TOKEN}
   - composer install --no-dev
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: php
+
+php:
+  - 7.2
+  - 7.3
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_script:
+  - echo | pecl install channel://pecl.php.net/yaml-2.0.4
+  - find src/ -type f -name '*.php' | xargs -n 1 php -l
+  - composer install --no-dev
+
+script:
+  - composer build

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "BigBrother",
+  "name": "bigbrotherteam/bigbrother",
   "description": "Allows the connection of Minecraft: PC clients to PocketMine-MP servers",
   "license": "LGPL-3.0",
   "authors": [

--- a/scripts/before_deploy
+++ b/scripts/before_deploy
@@ -4,12 +4,14 @@ BINTRAY_JSON="$(dirname $(readlink -f $0))/../build/bintray.json"
 GIT_REVISION="$(git describe --tags --always --dirty)"
 GIT_SHA1="$(git log -1 --format=[%h])"
 
+BINTRAY_SUBJECT="${BINTRAY_SUBJECT:-BigBrotherTeam}"
+
 cat<<EOF >"${BINTRAY_JSON}"
 {
   "package": {
     "name": "BigBrother",
     "repo": "Test",
-    "subject": "BigBrotherTeam",
+    "subject": "${BINTRAY_SUBJECT}",
     "desc": "Allows the connection of Minecraft: Java Edtion clients to PocketMine-MP servers. Made for PocketMine-MP",
     "website_url": "https://github.com/BigBrotherTeam/BigBrother",
     "issue_tracker_url": "https://github.com/BigBrotherTeam/BigBrother/issues",

--- a/scripts/before_deploy
+++ b/scripts/before_deploy
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+BINTRAY_JSON="$(dirname $(readlink -f $0))/../build/bintray.json"
+GIT_REVISION="$(git describe --tags --always --dirty)"
+GIT_SHA1="$(git log -1 --format=[%h])"
+
+cat<<EOF >"${BINTRAY_JSON}"
+{
+  "package": {
+    "name": "BigBrother",
+    "repo": "Test",
+    "subject": "BigBrotherTeam",
+    "desc": "Allows the connection of Minecraft: Java Edtion clients to PocketMine-MP servers. Made for PocketMine-MP",
+    "website_url": "https://github.com/BigBrotherTeam/BigBrother",
+    "issue_tracker_url": "https://github.com/BigBrotherTeam/BigBrother/issues",
+    "vcs_url": "https://github.com/BigBrotherTeam/BigBrother.git",
+    "github_use_tag_release_notes": false,
+    "licenses": ["LGPL-3.0"],
+    "labels": ["pocketmine", "pocketmine-mp", "minecraft", "mcpe-server", "mcpc-server", "php", "php72"],
+    "public_download_numbers": true,
+    "public_stats": true
+  },
+
+  "version": {
+    "name": "${GIT_REVISION}"
+  },
+
+  "files":
+    [
+      {"includePattern": "build/BigBrother.phar", "uploadPattern": "${TRAVIS_BRANCH}/BigBrother-${GIT_REVISION}${GIT_SHA1}.phar"}
+    ],
+  "publish": true
+}
+EOF
+
+cat "${BINTRAY_JSON}"

--- a/scripts/build
+++ b/scripts/build
@@ -30,7 +30,7 @@ define("PROJECT_ROOT", dirname(__FILE__, 2));
 define("DEVTOOL_REPO", "pmmp/PocketMine-DevTools");
 define("DEVTOOL_FILE", "/build/DevTools.phar");
 define("BIGBROS_FILE", "/build/BigBrother.phar");
-
+define("REVISION_FILE", "/resources/revision");
 define("GITHUB_API", "https://api.github.com/repos/%s/releases");
 define("USER_AGENT", "User-Agent: Mozilla/5.0 like Gecko");
 
@@ -41,6 +41,12 @@ try {
 	if(ini_get("phar.readonly") == 1){
 		system(join(' ', array_merge([PHP_BINARY, '-dphar.readonly=0'], $argv)), $value);
 		exit($value);
+	}
+
+	@unlink(PROJECT_ROOT . REVISION_FILE);
+	@exec("git describe --tags --always --dirty", $revision, $value);
+	if($value == 0){
+		file_put_contents(PROJECT_ROOT . REVISION_FILE, $revision[0]);
 	}
 
 	/**

--- a/scripts/build
+++ b/scripts/build
@@ -28,8 +28,8 @@
 
 define("PROJECT_ROOT", dirname(__FILE__, 2));
 define("DEVTOOL_REPO", "pmmp/PocketMine-DevTools");
-define("DEVTOOL_FILE", "/dists/DevTools.phar");
-define("BIGBROS_FILE", "/dists/BigBrother.phar");
+define("DEVTOOL_FILE", "/build/DevTools.phar");
+define("BIGBROS_FILE", "/build/BigBrother.phar");
 
 define("GITHUB_API", "https://api.github.com/repos/%s/releases");
 define("USER_AGENT", "User-Agent: Mozilla/5.0 like Gecko");

--- a/scripts/build
+++ b/scripts/build
@@ -48,15 +48,37 @@ try {
 	 * to avoid reaching github API rate limit
 	 */
 	if(!file_exists(PROJECT_ROOT . DEVTOOL_FILE) or time() > ($atime = fileatime(PROJECT_ROOT . DEVTOOL_FILE)) +900){
+		$headers = [
+			"User-Agent: ". USER_AGENT,
+		];
+
+		if($GITHUB_OAUTH_TOKEN = getenv("GITHUB_OAUTH_TOKEN")){
+			$headers[] = "Authorization: bearer $GITHUB_OAUTH_TOKEN";
+		}
+
+		$ctx = stream_context_create(["http" => ["header" => join("\r\n", $headers)]]);
+
 		//query latest devtool release
-		$ctx = stream_context_create(["http" => ["header" => "User-Agent: ". USER_AGENT]]);
-		$asset = json_decode(@file_get_contents(sprintf(GITHUB_API, DEVTOOL_REPO), false, $ctx))[0]->assets[0];
+		$releases = json_decode(file_get_contents(sprintf(GITHUB_API, DEVTOOL_REPO), false, $ctx));
+		if(!is_array($releases)) {
+			echo "Failed to retrieve DevTools release info from github" . PHP_EOL;
+			exit(1);
+		}
 
 		//check if devtools is up to date
-		if(!isset($atime) or strtotime($asset->updated_at) > $atime){
-			@mkdir(dirname(PROJECT_ROOT . DEVTOOL_FILE));
+		if(!isset($atime) or strtotime($releases[0]->assets[0]->updated_at) > $atime){
+			$asset = $releases[0]->assets[0];
+
+			mkdir(dirname(PROJECT_ROOT . DEVTOOL_FILE));
 			echo sprintf("Downloading DevTools from '%s'", $asset->browser_download_url) . PHP_EOL;
-			@file_put_contents(PROJECT_ROOT . DEVTOOL_FILE, @file_get_contents($asset->browser_download_url));
+
+			$binary = file_get_contents($asset->browser_download_url);
+			if($binary === false){
+				echo "Failed to download DevTools.phar" . PHP_EOL;
+				exit(1);
+			}
+
+			file_put_contents(PROJECT_ROOT . DEVTOOL_FILE, $binary);
 		}
 	}
 

--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -120,6 +120,8 @@ class BigBrother extends PluginBase implements Listener{
 						$this->getLogger()->info("BigBrother revision: ".$revision[0]);
 					}
 					chdir($cwd);
+				}elseif(($resource = $this->getResource("revision")) and ($revision = stream_get_contents($resource))){
+					$this->getLogger()->info("BigBrother.phar; revision: ".$revision);
 				}
 
 				$aes = new AES(AES::MODE_CFB8);


### PR DESCRIPTION
## Introduction
Since, we introduce the composer dependency management system, it is difficult to build plugin phar archive. So, I wrote this PR to support continuous integration and deployments.

This patch also introduce revision number in resource file, so that we can distinguish which version of build is running when bug reported.

### Follow-up
I need some permission to configure Travis-CI, and Bintray.
<!--- Thank you for sending pull-request! -->