### PR TITLE
fix #145 implement profile cache to avoid reaching rate limit of mojang server

### DIFF
--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -71,6 +71,9 @@ class BigBrother extends PluginBase implements Listener{
 	/** @var Translator */
 	protected $translator;
 
+	/** @var array */
+	protected $profileCache = [];
+
 	/**
 	 * @override
 	 */
@@ -240,6 +243,30 @@ class BigBrother extends PluginBase implements Listener{
 	 */
 	public function decryptBinary(string $cipher) : string{
 		return $this->rsa->decrypt($cipher);
+	}
+
+	/**
+	 * @param string $username
+	 * @return array|null
+	 */
+	public function getProfileCache(string $username, int $timeout=60){
+		if(isset($this->profileCache[$username]) && (microtime(true) - $this->profileCache[$username]["timestamp"] < $timeout)){
+			return $this->profileCache[$username]["profile"];
+		}else{
+			unset($this->profileCache[$username]);
+			return null;
+		}
+	}
+
+	/**
+	 * @param string $username
+	 * @param array profile
+	 */
+	public function setProfileCache(string $username, array $profile) : void{
+		$this->profileCache[$username] = [
+			"timestamp" => microtime(true),
+			"profile" => $profile
+		];
 	}
 
 	/**

--- a/src/shoghicp/BigBrother/DesktopPlayer.php
+++ b/src/shoghicp/BigBrother/DesktopPlayer.php
@@ -669,7 +669,6 @@ class DesktopPlayer extends Player{
 				$this->putRawPacket($pk);
 			}else{
 				if($info = $this->plugin->getProfileCache($username)){
-					echo "cache hit !!".PHP_EOL;
 					$this->bigBrother_authenticate($info["id"], $info["properties"]);
 				}else{
 					$this->getServer()->getAsyncPool()->submitTask(new class($this->plugin, $this, $username) extends AsyncTask{


### PR DESCRIPTION
## Introduction
This PR introduce profile caching mechanism to avoid reaching rate limit of mojang profile server.
This patch fixes the issue reported in #145 and some login related issue frequently reported.

### Changes
* When user login first time, try to fetch profile data from mojang server and store them into cache
* When user retry login whithin 60 seconds from last login, we use cache

### Follow-up
May need some refactoring
<!--- Thank you for sending pull-request! -->