### PR TITLE
Fix #120 login timeout issue when online-mode: false

### DIFF
--- a/src/shoghicp/BigBrother/DesktopPlayer.php
+++ b/src/shoghicp/BigBrother/DesktopPlayer.php
@@ -698,7 +698,7 @@ class DesktopPlayer extends Player{
 							if($status === 204){
 								$this->publishProgress("UserNotFound: failed to fetch profile for '$this->username'; status=$status; err=$err; response_header=".json_encode($header));
 								$this->setResult([
-									"id" => str_replace("-", "", UUID::fromRandom()),
+									"id" => str_replace("-", "", UUID::fromData("OfflinePlayer:", $this->username)),
 									"name" => $this->username,
 									"properties" => []
 								]);

--- a/src/shoghicp/BigBrother/DesktopPlayer.php
+++ b/src/shoghicp/BigBrother/DesktopPlayer.php
@@ -52,6 +52,7 @@ use pocketmine\level\format\Chunk;
 use pocketmine\timings\Timings;
 use pocketmine\utils\Internet;
 use pocketmine\utils\TextFormat;
+use pocketmine\utils\UUID;
 use shoghicp\BigBrother\network\Packet;
 use shoghicp\BigBrother\network\protocol\Login\EncryptionRequestPacket;
 use shoghicp\BigBrother\network\protocol\Login\EncryptionResponsePacket;
@@ -696,7 +697,11 @@ class DesktopPlayer extends Player{
 							$response = Internet::getURL("https://api.mojang.com/users/profiles/minecraft/".$this->username, 10, [], $err, $header, $status);
 							if($status === 204){
 								$this->publishProgress("UserNotFound: failed to fetch profile for '$this->username'; status=$status; err=$err; response_header=".json_encode($header));
-								$this->setResult(false);
+								$this->setResult([
+									"id" => str_replace("-", "", UUID::fromRandom()),
+									"name" => $this->username,
+									"properties" => []
+								]);
 								return;
 							}
 


### PR DESCRIPTION
## Introduction
This patch solve #120 login timeout issue when online-mode: false

### Changes
* Set random uuid when user is not registered in mojang server

### Follow-up
it may be better if we use following code instead of  `UUID::fromRandom()`.
```php
UUID::fromData("BigBrother", $this->username);
```
<!--- Thank you for sending pull-request! -->