### PR TITLE
1.14.60 support

### DIFF
--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -86,7 +86,7 @@ class BigBrother extends PluginBase implements Listener{
 		}
 
 		if($enable){
-			if(Info::CURRENT_PROTOCOL === 389){
+			if(Info::CURRENT_PROTOCOL === 390){
 				ConvertUtils::init();
 
 				$this->saveDefaultConfig();


### PR DESCRIPTION
## Introduction

Adds support for Minecraft: Bedrock Edition version 1.14.60

### Behavioural changes

None, just support for 1.14.60

### Follow-up
If it works, then you could merge this pull request.

<!--- Thank you for sending pull-request! -->