### PR TITLE
support Github Actions for building BigBrother.phar for each commit on any branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: build
+on: push
+jobs:
+  build:
+    name: build plugin
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - 7.3.25
+          - 7.4.13
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+
+      - name: install dependencies
+        run:
+          sudo apt update && sudo apt install -y re2c libtool libtool-bin zlib1g-dev libcurl4-openssl-dev libxml2-dev libyaml-dev libgmp-dev libzip-dev libssl-dev libtidy-dev libxslt-dev libonig-dev libmcrypt-dev
+
+      - name: setup path
+        run: echo ~/.phpenv/bin >>$GITHUB_PATH
+
+      - name: setup php
+        run: |
+          git clone https://github.com/phpenv/phpenv.git ~/.phpenv
+          git clone https://github.com/php-build/php-build $(phpenv root)/plugins/php-build
+
+          eval "$(phpenv init -)"
+          phpenv install ${{ matrix.php }}
+          phpenv local ${{ matrix.php }}
+
+          git clone https://github.com/pmmp/pthreads.git
+          cd pthreads
+          git checkout 2bcd8b8c10395d58b8a9bc013e3a5328080c867f
+          phpize
+
+          ./configure
+          make -j4
+          make install
+
+          echo "extension=pthreads.so" > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/pthreads.ini
+        env:
+          PHP_BUILD_CONFIGURE_OPTS: "--enable-maintainer-zts"
+          PHP_BUILD_INSTALL_EXTENSION: "yaml=2.0.4"
+          PHP_BUILD_EXTRA_MAKE_ARGUMENTS: "-j4"
+
+      - name: build plugin
+        run: |
+          eval "$(phpenv init -)"
+          composer install
+          composer build
+
+      - name: upload artifact
+        uses: actions/upload-artifact@v2
+        if: ${{ matrix.php == '7.4.13' }}
+        with:
+          name: BigBrother.phar
+          path: build/BigBrother.phar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,20 +15,37 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: cache apt
+        id: cache-apt
+        uses: actions/cache@v2
+        with:
+          path: /var/cache/apt
+          key: ${{ runner.os }}-apt
+
       - name: install dependencies
         run:
           sudo apt update && sudo apt install -y re2c libtool libtool-bin zlib1g-dev libcurl4-openssl-dev libxml2-dev libyaml-dev libgmp-dev libzip-dev libssl-dev libtidy-dev libxslt-dev libonig-dev libmcrypt-dev
+
+      - name: cache phpenv
+        id: cache-phpenv
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.phpenv
+            .php-version
+          key: ${{ runner.os }}-phpenv-${{ matrix.php }}
 
       - name: setup path
         run: echo ~/.phpenv/bin >>$GITHUB_PATH
 
       - name: setup php
+        if: steps.cache-phpenv.outputs.cache-hit != 'true'
         run: |
           git clone https://github.com/phpenv/phpenv.git ~/.phpenv
           git clone https://github.com/php-build/php-build $(phpenv root)/plugins/php-build
 
           eval "$(phpenv init -)"
-          phpenv install ${{ matrix.php }}
+          phpenv install -s ${{ matrix.php }}
           phpenv local ${{ matrix.php }}
 
           git clone https://github.com/pmmp/pthreads.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 cache:
   directories:
     - $HOME/.composer/cache
+    - build/DevTools.phar
 
 install:
   - echo | pecl install channel://pecl.php.net/yaml-2.0.4


### PR DESCRIPTION
## Introduction
Currently we are using Travis-CI and Bintray for CI/CD.
But it is bit difficult to setup these environment and the build task is limited on specific branch.
And since the plugin requires composer for dependency management, it is different from normal PMMP plugin build.

So, I wrote a Github Action script to build the plugin for each commit on any branch.
Github Action is integrated to Github itself, and it is enabled by default.
So, you don't need to setup CI/CD for Github Actions.
Just commit and push it to your repo.
It may help someone who want to develop this plugin.

It takes about 10 minutes first time because it builds php binaries and extensions from source.
When CI was triggered after second time, it uses prebuilt php binariy and extensions.

### Behavioural changes

* Nothing

### Follow-up


<!--- Thank you for sending pull-request! -->