### PR TITLE
Add Dockerfile for CI and plugin build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,10 @@
 name: build
 on: push
 jobs:
-  build:
-    name: build plugin
+  docker:
+    name: build docker image
     runs-on: ubuntu-latest
-    container:
-      image: php:${{ matrix.php }}-zts
+    if: ${{ github.repository_owner == 'BigBrotherTeam' }}
     strategy:
       matrix:
         php:
@@ -17,32 +16,49 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: install dependencies
-        run: |
-          apt update
-          apt-get install -y git curl libyaml-dev
+      - name: Rewrite Image Version
+        run: sed -i -e "s/FROM php:7/FROM php:${{ matrix.php }}/" Dockerfile
 
-      - name: install yaml extension
-        run: |
-          pecl install channel://pecl.php.net/yaml-2.0.4
-          docker-php-ext-enable yaml
+      - name: Login GitHub Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
 
-      - name: install sockets extension
-        run: docker-php-ext-install sockets
+      - name: Build Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: |
+            ghcr.io/bigbrotherteam/bigbrother/php:${{ matrix.php }}
+            ghcr.io/bigbrotherteam/bigbrother/php:latest
 
-      - name: install pthreads extension
-        run: |
-          git clone https://github.com/pmmp/pthreads.git /usr/local/src/pthreads
-          cd /usr/local/src/pthreads
-          git checkout 2bcd8b8c10395d58b8a9bc013e3a5328080c867f
-          phpize
-          ./configure
-          make
-          make install
-          docker-php-ext-enable pthreads
+      - name: Push Docker image
+        run: docker push ghcr.io/bigbrotherteam/bigbrother/php:${{ matrix.php }}
 
-      - name: install composer
-        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+      - name: Update Latest
+        if: matrix.php == '7.4.13'
+        run: docker push ghcr.io/bigbrotherteam/bigbrother/php:latest
+
+
+  build:
+    name: build plugin
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: docker
+    container:
+      image: ghcr.io/bigbrotherteam/bigbrother/php:${{ matrix.php }}
+    strategy:
+      matrix:
+        php:
+          - 7.3.25
+          - 7.4.13
+
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
 
       - name: build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ jobs:
   build:
     name: build plugin
     runs-on: ubuntu-latest
+    container:
+      image: php:${{ matrix.php }}-zts
     strategy:
       matrix:
         php:
@@ -15,57 +17,35 @@ jobs:
         with:
           fetch-depth: 1
 
-      - name: cache apt
-        id: cache-apt
-        uses: actions/cache@v2
-        with:
-          path: /var/cache/apt
-          key: ${{ runner.os }}-apt
-
       - name: install dependencies
-        run:
-          sudo apt update && sudo apt install -y re2c libtool libtool-bin zlib1g-dev libcurl4-openssl-dev libxml2-dev libyaml-dev libgmp-dev libzip-dev libssl-dev libtidy-dev libxslt-dev libonig-dev libmcrypt-dev
-
-      - name: cache phpenv
-        id: cache-phpenv
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.phpenv
-            .php-version
-          key: ${{ runner.os }}-phpenv-${{ matrix.php }}
-
-      - name: setup path
-        run: echo ~/.phpenv/bin >>$GITHUB_PATH
-
-      - name: setup php
-        if: steps.cache-phpenv.outputs.cache-hit != 'true'
         run: |
-          git clone https://github.com/phpenv/phpenv.git ~/.phpenv
-          git clone https://github.com/php-build/php-build $(phpenv root)/plugins/php-build
+          apt update
+          apt-get install -y git curl libyaml-dev
 
-          eval "$(phpenv init -)"
-          phpenv install -s ${{ matrix.php }}
-          phpenv local ${{ matrix.php }}
+      - name: install yaml extension
+        run: |
+          pecl install channel://pecl.php.net/yaml-2.0.4
+          docker-php-ext-enable yaml
 
-          git clone https://github.com/pmmp/pthreads.git
-          cd pthreads
+      - name: install sockets extension
+        run: docker-php-ext-install sockets
+
+      - name: install pthreads extension
+        run: |
+          git clone https://github.com/pmmp/pthreads.git /usr/local/src/pthreads
+          cd /usr/local/src/pthreads
           git checkout 2bcd8b8c10395d58b8a9bc013e3a5328080c867f
           phpize
-
           ./configure
-          make -j4
+          make
           make install
+          docker-php-ext-enable pthreads
 
-          echo "extension=pthreads.so" > ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/pthreads.ini
-        env:
-          PHP_BUILD_CONFIGURE_OPTS: "--enable-maintainer-zts"
-          PHP_BUILD_INSTALL_EXTENSION: "yaml=2.0.4"
-          PHP_BUILD_EXTRA_MAKE_ARGUMENTS: "-j4"
+      - name: install composer
+        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-      - name: build plugin
+      - name: build
         run: |
-          eval "$(phpenv init -)"
           composer install
           composer build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM php:7-zts
+
+RUN apt update
+RUN apt-get install -y git curl libyaml-dev
+
+RUN docker-php-ext-install sockets
+
+RUN pecl install channel://pecl.php.net/yaml-2.0.4
+RUN docker-php-ext-enable yaml
+
+RUN git clone https://github.com/pmmp/pthreads.git /usr/local/src/pthreads && \
+	cd /usr/local/src/pthreads && \
+	git checkout 2bcd8b8c10395d58b8a9bc013e3a5328080c867f && \
+	phpize && \
+	./configure && \
+	make && \
+	make install && \
+	docker-php-ext-enable pthreads
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+CMD composer build


### PR DESCRIPTION
## Introduction
Since, PMMP require PHP7.3+ with ZTS enabled binary and some extensions, It is bit difficult to reproduce building environment.
So, I wrote a Dockerfile to make it easy for CI/CD and plugin building task itself.
If you have Docker already installed, you can build this plugin with following command.

```
docker run --rm -w /usr/local/src -v ${PWD}:/usr/local/src ghcr.io/bigbrotherteam/bigbrother/php
```

Note: If you are using Docker Desktop for Windows, please use powershell instead of command prompt.

### Behavioural changes



### Follow-up


<!--- Thank you for sending pull-request! -->