### PR TITLE
disable uploading artifact when build on base branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: upload artifact
         uses: actions/upload-artifact@v2
-        if: ${{ matrix.php == '7.4.13' }}
+        if: ${{ matrix.php == '7.4.13' && github.ref != 'refs/heads/base' }}
         with:
           name: BigBrother.phar
           path: build/BigBrother.phar

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ jobs:
   docker:
     name: build docker image
     runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'BigBrotherTeam' }}
+    if: ${{ github.repository_owner == 'BigBrotherTeam' && github.ref == 'refs/head/base' }}
     strategy:
       matrix:
         php:


### PR DESCRIPTION
## Introduction
Since base branch is introduced as a branch sharing common changes, it is not intended to build plugins.
So, it may confuse users who use these phar plugins built with github actions CI on base branch.
This patch disable artifact upload on base branch.

### Behavioural changes



### Follow-up


<!--- Thank you for sending pull-request! -->