### PR TITLE
[WIP] Rewrite version of phar plugin package

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -5,4 +5,5 @@ author: BigBrotherTeam
 version: 1.6.0-beta
 api: [3.7.0]
 description: "Allows the connection of Minecraft: PC clients to PocketMine-MP servers"
+author: BigBrotherTeam
 website: https://github.com/BigBrotherTeam/BigBrother

--- a/scripts/build
+++ b/scripts/build
@@ -99,7 +99,6 @@ try {
 
 	$phar = new Phar(PROJECT_ROOT . BIGBROS_FILE);
 	if($revision){
-		$phar->setStub(preg_replace('/^Version:.*$/m', "Version: $revision", $phar->getStub()));
 		$phar->addFromString('plugin.yml', preg_replace('/^version:.*$/m', "version: $revision", file_get_contents(PROJECT_ROOT . '/plugin.yml')));
 	}
 

--- a/scripts/build
+++ b/scripts/build
@@ -35,7 +35,7 @@ define("GITHUB_API", "https://api.github.com/repos/%s/releases");
 define("USER_AGENT", "User-Agent: Mozilla/5.0 like Gecko");
 
 $include_dirs  = ['src', 'resources', 'vendor'];
-$include_files = ['LICENSE', 'README.md', 'plugin.yml'];
+$include_files = ['LICENSE', 'README.md'];
 
 try {
 	if(ini_get("phar.readonly") == 1){
@@ -45,8 +45,8 @@ try {
 
 	@unlink(PROJECT_ROOT . REVISION_FILE);
 	@exec("git describe --tags --always --dirty", $revision, $value);
-	if($value == 0){
-		file_put_contents(PROJECT_ROOT . REVISION_FILE, $revision[0]);
+	if($revision = $value == 0 ? $revision[0] : null){
+		file_put_contents(PROJECT_ROOT . REVISION_FILE, $revision);
 	}
 
 	/**
@@ -101,6 +101,11 @@ try {
 	system($command);
 
 	$phar = new Phar(PROJECT_ROOT . BIGBROS_FILE);
+	if($revision){
+		$phar->setStub(preg_replace('/^Version:.*$/m', "Version: $revision", $phar->getStub()));
+		$phar->addFromString('plugin.yml', preg_replace('/^version:.*$/m', "version: $revision", file_get_contents(PROJECT_ROOT . '/plugin.yml')));
+	}
+
 	foreach ($include_files as $file){
 		$phar->addFile(PROJECT_ROOT . '/' . $file, $file);
 	}

--- a/scripts/build
+++ b/scripts/build
@@ -78,13 +78,10 @@ try {
 			mkdir(dirname(PROJECT_ROOT . DEVTOOL_FILE));
 			echo sprintf("Downloading DevTools from '%s'", $asset->browser_download_url) . PHP_EOL;
 
-			$binary = file_get_contents($asset->browser_download_url);
-			if($binary === false){
+			if(!copy($asset->browser_download_url, PROJECT_ROOT . DEVTOOL_FILE)){
 				echo "Failed to download DevTools.phar" . PHP_EOL;
 				exit(1);
 			}
-
-			file_put_contents(PROJECT_ROOT . DEVTOOL_FILE, $binary);
 		}
 	}
 

--- a/scripts/build
+++ b/scripts/build
@@ -111,6 +111,6 @@ try {
 	}
 }catch(Exception $e){
 	echo "unexpected error has occurred!" . PHP_EOL;
-	echo $e->getTraceAsString() . PHP_EOL;
+	echo $e . PHP_EOL;
 	exit(1);
 }


### PR DESCRIPTION
## Introduction
We have currently no stable release, so plugin is released under as is basis.
But the current version number representation has no meaning because it is always same '1.6.0-beta'.
And it is not convenient for debubuging / bug report.
So I wrote a PR for rewriting version number with git revision when building plugin in phar format.

### Behavioural changes
Nothing.

### Follow-up


<!--- Thank you for sending pull-request! -->