### PR TITLE
Support v1.17.10 (Protocol 448)

### DIFF
--- a/src/shoghicp/BigBrother/BigBrother.php
+++ b/src/shoghicp/BigBrother/BigBrother.php
@@ -87,7 +87,7 @@ class BigBrother extends PluginBase implements Listener{
 		}
 
 		if($enable){
-			if(Info::CURRENT_PROTOCOL === 422){
+			if(Info::CURRENT_PROTOCOL === 448){
 				ConvertUtils::init();
 
 				$this->saveDefaultConfig();

--- a/src/shoghicp/BigBrother/DesktopPlayer.php
+++ b/src/shoghicp/BigBrother/DesktopPlayer.php
@@ -577,6 +577,7 @@ class DesktopPlayer extends Player{
 			}
 
 			$skin = new SkinImage($skinImage);
+			$pk->clientData["PlayFabId"] = "";
 			$pk->clientData["SkinData"] = $skin->getSkinImageData(true);
 			$skinSize = $this->getSkinImageSize(strlen($skin->getRawSkinImageData(true)));
 			$pk->clientData["SkinImageHeight"] = $skinSize[0];

--- a/src/shoghicp/BigBrother/network/Packet.php
+++ b/src/shoghicp/BigBrother/network/Packet.php
@@ -30,6 +30,7 @@ declare(strict_types=1);
 namespace shoghicp\BigBrother\network;
 
 use pocketmine\item\Item;
+use pocketmine\network\mcpe\protocol\types\inventory\ItemStackWrapper;
 use shoghicp\BigBrother\utils\Binary;
 use shoghicp\BigBrother\utils\ConvertUtils;
 use shoghicp\BigBrother\utils\ComputerItem;
@@ -103,7 +104,10 @@ abstract class Packet extends stdClass{
 		}
 	}
 
-	protected function putSlot(Item $item) : void{
+	protected function putSlot($item) : void{
+		if($item instanceof ItemStackWrapper) {
+			$item = $item->getItemStack();
+		}
 		ConvertUtils::convertItemData(true, $item);
 
 		if($item->getID() === 0){


### PR DESCRIPTION
## Introduction
Support PocketMine-MP protocol v1.17.10 (448) and another fixes
![Screenshot (1536)](https://user-images.githubusercontent.com/35138228/127996162-9cd434f9-5ae0-4c71-9c94-c5b0894f5c1e.png)

### Behavioural changes
- Support for PocketMine-MP protocol version 1.17.10 (448)
- Remove destroy block particle, because in Java destroy block particle is proceed client side
- Fix when take item from creative Inventory

### Follow-up


<!--- Thank you for sending pull-request! -->